### PR TITLE
Add Song Converter Dynamic Properties

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,4 @@ generate:
 	@go run --tags="generate" ./ebook-lint/main.go generate -g ./ebook-lint/
 	@go run --tags="generate" ./jp-proc/main.go generate -g ./jp-proc/
 	@go run --tags="generate" ./magnum/main.go generate -g ./magnum/
+	@go run --tags="generate" ./song-converter/main.go generate -g ./song-converter/

--- a/song-converter/README.md
+++ b/song-converter/README.md
@@ -1,0 +1,67 @@
+<!-- This file is generated from  https://github.com/pjkaufman/go-go-gadgets/song-converter/README.md.tmpl. Please make any necessary changes there. -->
+
+# Song Converter
+
+This is a program that helps converter some Markdown files with YAML frontmatter into html or csv to help with creating a song book.
+
+## Commands
+
+- [create-csv](#create-csv)
+- [create-html](#create-html)
+
+### create-csv
+
+How it works:
+- Reads in all of the files in the specified folder.
+- Sorts the files alphabetically
+- Converts each file into a CSV row
+- Writes the content to the specified source
+
+
+#### Flags
+
+| Short Name | Long Name | Description | Value Type | Default Value | Is Required | Other Notes |
+| ---------- | --------- | ----------- | ---------- | ------------- | ----------- | ----------- |
+| o | output-file | the file to write the csv to | string |  | false | Should be a file with one of the following extensions: csv |
+| d | working-dir | the directory where the Markdown files are located | string |  | true | Should be a directory |
+
+#### Usage
+
+``` bash
+# To write the output of converting the files in the specified folder into a csv format to a file:
+song-converter create-csv -d working-dir -o churchSongs.csv
+
+# To write the output of converting the files in the specified folder into a csv format to std out:
+song-converter create-csv -d working-dir
+```
+
+### create-html
+
+How it works:
+- Reads in all of the files in the specified folder
+- Sorts the files alphabetically
+- Adds the cover to the start of the content after converting it to html
+- Converts each file into html
+- Writes the content to the specified source
+
+
+#### Flags
+
+| Short Name | Long Name | Description | Value Type | Default Value | Is Required | Other Notes |
+| ---------- | --------- | ----------- | ---------- | ------------- | ----------- | ----------- |
+| c | cover-file | the markdown cover file to use | string |  | true | Should be a file with one of the following extensions: md |
+| o | output | the html file to write the output to | string |  | false | Should be a file with one of the following extensions: html |
+| v | version-type | the version descriptor for the type of songs to generate (generally just abridged or unabridged) | string |  | true |  |
+| d | working-dir | the directory where the Markdown files are located | string |  | true | Should be a directory |
+
+#### Usage
+
+``` bash
+# To write the output of converting the files in the specified folder to html to a file:
+song-converter create-html -d working-dir -c cover.md -o songs.html
+
+# To write the output of converting the files in the specified folder to html to std out:
+song-converter create-html -d working-dir -s cover.md
+```
+
+

--- a/song-converter/README.md.tmpl
+++ b/song-converter/README.md.tmpl
@@ -1,0 +1,18 @@
+<!-- This file is generated from  https://github.com/pjkaufman/go-go-gadgets/song-converter/README.md.tmpl. Please make any necessary changes there. -->
+
+# {{ .Title }}
+
+{{ .Description }}
+
+{{- if .Todos }}
+
+## TODOs
+
+{{- range .Todos }}
+- {{ . }}
+{{- end}}
+{{- end}}
+
+## Commands
+
+{{ .CommandStrings }}

--- a/song-converter/cmd/create-csv.go
+++ b/song-converter/cmd/create-csv.go
@@ -85,7 +85,7 @@ var createCsvCmd = &cobra.Command{
 }
 
 func init() {
-	SongConverterCmd.AddCommand(createCsvCmd)
+	rootCmd.AddCommand(createCsvCmd)
 
 	createCsvCmd.Flags().StringVarP(&stagingDir, "working-dir", "d", "", "the directory where the Markdown files are located")
 	err := createCsvCmd.MarkFlagRequired("working-dir")

--- a/song-converter/cmd/create-html.go
+++ b/song-converter/cmd/create-html.go
@@ -133,7 +133,7 @@ var CreateHtmlCmd = &cobra.Command{
 }
 
 func init() {
-	SongConverterCmd.AddCommand(CreateHtmlCmd)
+	rootCmd.AddCommand(CreateHtmlCmd)
 
 	CreateHtmlCmd.Flags().StringVarP(&stagingDir, "working-dir", "d", "", "the directory where the Markdown files are located")
 	err := CreateHtmlCmd.MarkFlagRequired("working-dir")

--- a/song-converter/cmd/create-html.go
+++ b/song-converter/cmd/create-html.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/MakeNowJust/heredoc"
 	filehandler "github.com/pjkaufman/go-go-gadgets/pkg/file-handler"
@@ -40,6 +41,7 @@ var (
 	bodyHtmlOutputFile string
 	coverOutputFile    string
 	coverInputFilePath string
+	versionDescriptor  string
 )
 
 // CreateHtmlCmd represents the CreateSongs command
@@ -84,7 +86,7 @@ var CreateHtmlCmd = &cobra.Command{
 			logger.WriteError(err.Error())
 		}
 
-		coverHtml := converter.BuildHtmlCover(coverMd)
+		coverHtml := converter.BuildHtmlCover(coverMd, versionDescriptor, time.Now())
 
 		if isWritingToFile {
 			logger.WriteInfo("Finished creating html cover file")
@@ -159,6 +161,12 @@ func init() {
 	err = CreateHtmlCmd.MarkFlagFilename("output", "html")
 	if err != nil {
 		logger.WriteErrorf("failed to mark flag \"output\" as a looking for specific file types on create html command: %v\n", err)
+	}
+
+	CreateHtmlCmd.Flags().StringVarP(&versionDescriptor, "version-type", "v", "", "the version descriptor for the type of songs to generate (generally just abridged or unabridged)")
+	err = CreateHtmlCmd.MarkFlagRequired("version-type")
+	if err != nil {
+		logger.WriteErrorf("failed to mark flag \"version-type\" as required on create html command: %v\n", err)
 	}
 }
 

--- a/song-converter/cmd/generate.go
+++ b/song-converter/cmd/generate.go
@@ -1,0 +1,16 @@
+//go:build generate
+
+package cmd
+
+import (
+	cmdhandler "github.com/pjkaufman/go-go-gadgets/pkg/cmd-handler"
+)
+
+const (
+	title       = "Song Converter"
+	description = "This is a program that helps converter some Markdown files with YAML frontmatter into html or csv to help with creating a song book."
+)
+
+func init() {
+	cmdhandler.AddGenerateCmd(rootCmd, title, description, []string{}, nil)
+}

--- a/song-converter/cmd/root.go
+++ b/song-converter/cmd/root.go
@@ -9,8 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// SongConverterCmd represents the base command when called without any subcommands
-var SongConverterCmd = &cobra.Command{
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
 	Use:   "song-converter",
 	Short: "Some commands for converting songs from Markdown with YAML frontmatter over to html",
 }
@@ -18,7 +18,7 @@ var SongConverterCmd = &cobra.Command{
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := SongConverterCmd.Execute()
+	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/song-converter/internal/converter/build-html-cover.go
+++ b/song-converter/internal/converter/build-html-cover.go
@@ -3,9 +3,13 @@ package converter
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
-func BuildHtmlCover(coverMd string) string {
+func BuildHtmlCover(coverMd, bookType string, currentTime time.Time) string {
+	coverMd = strings.Replace(coverMd, "{{DATE_GENERATED}}", currentTime.Format("Jan 2006"), 1)
+	coverMd = strings.Replace(coverMd, "{{TYPE}}", bookType, 1)
+
 	coverHtml := mdToHTML([]byte(coverMd))
 	coverHtml = fmt.Sprintf("<div style=\"text-align: center\">\n%s</div>\n", coverHtml)
 

--- a/song-converter/internal/converter/build-html-cover_test.go
+++ b/song-converter/internal/converter/build-html-cover_test.go
@@ -3,6 +3,7 @@
 package converter_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,19 +14,29 @@ import (
 type BuildHtmlCoverTestCase struct {
 	InputCoverMd string
 	ExpectedHtml string
+	Type         string
+	DateCreated  time.Time
 }
 
 var BuildHtmlCoverTestCases = map[string]BuildHtmlCoverTestCase{
 	"a valid file should properly get turned into html with no style content": {
 		InputCoverMd: coverFileMd,
-		ExpectedHtml: coverFileHtml,
+		ExpectedHtml: fmt.Sprintf(coverFileHtmlFormat, "abridged", "Abridged", "Jul 2024"),
+		Type:         "Abridged",
+		DateCreated:  time.Date(2024, time.July, 1, 0, 0, 0, 0, time.Local),
+	},
+	"a valid file should properly get turned into html and respect the type and created date info": {
+		InputCoverMd: coverFileMd,
+		ExpectedHtml: fmt.Sprintf(coverFileHtmlFormat, "unabridged", "Unabridged", "Jan 2021"),
+		Type:         "Unabridged",
+		DateCreated:  time.Date(2021, time.January, 1, 0, 0, 0, 0, time.Local),
 	},
 }
 
 func TestBuildHtmlCover(t *testing.T) {
 	for name, args := range BuildHtmlCoverTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := converter.BuildHtmlCover(args.InputCoverMd, "Abridged", time.Now())
+			actual := converter.BuildHtmlCover(args.InputCoverMd, args.Type, args.DateCreated)
 
 			assert.Equal(t, args.ExpectedHtml, actual)
 		})

--- a/song-converter/internal/converter/build-html-cover_test.go
+++ b/song-converter/internal/converter/build-html-cover_test.go
@@ -4,6 +4,7 @@ package converter_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/pjkaufman/go-go-gadgets/song-converter/internal/converter"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ var BuildHtmlCoverTestCases = map[string]BuildHtmlCoverTestCase{
 func TestBuildHtmlCover(t *testing.T) {
 	for name, args := range BuildHtmlCoverTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := converter.BuildHtmlCover(args.InputCoverMd)
+			actual := converter.BuildHtmlCover(args.InputCoverMd, "Abridged", time.Now())
 
 			assert.Equal(t, args.ExpectedHtml, actual)
 		})

--- a/song-converter/internal/converter/constants_test.go
+++ b/song-converter/internal/converter/constants_test.go
@@ -3,9 +3,10 @@
 package converter_test
 
 const (
-	coverFileMd = `# Church Songs - E Version
+	coverFileMd = `# Church Songs - E Version {{TYPE}}
 
-<br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/>
+Date: {{DATE_GENERATED}}
+<br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/>
 
 ### Key:
 
@@ -29,9 +30,10 @@ ZW= Zelma Wanagas
 non returns*
 
 *\*Punctuation alters the alphabetical order*`
-	coverFileHtml = `<div style="text-align: center">
-<h1 id="church-songs-e-version">Church Songs - E Version</h1>
-<p><br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/></p>
+	coverFileHtmlFormat = `<div style="text-align: center">
+<h1 id="church-songs-e-version-%s">Church Songs - E Version %s</h1>
+<p>Date: %s
+<br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/> <br/></p>
 <h3 id="key">Key:</h3>
 <h4 id="books">Books</h4>
 <p>R=Red Book (Songs We Love)<br>


### PR DESCRIPTION
Add the ability to dynamically set the type of church song version on the cover page and the month and year info on the cover page for the generated file.

Updated the UTs to account for the updated logic and added the generation of the README file for song converter.