### PR TITLE
Ebook Lint: Swap to Copying from Zip to Zip and Cut Out Temp File

### DIFF
--- a/ebook-lint/cmd/cbr/to-cbz.go
+++ b/ebook-lint/cmd/cbr/to-cbz.go
@@ -34,7 +34,7 @@ var cbrToCbzCmd = &cobra.Command{
 
 		logger.WriteInfo("Starting converting cbr files to cbz files\n")
 
-		cbrs, err := filehandler.MustGetAllFilesWithExtInASpecificFolder(dir, ".cbr")
+		cbrs, err := filehandler.GetAllFilesWithExtInASpecificFolder(dir, ".cbr")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}

--- a/ebook-lint/cmd/cbz/compress.go
+++ b/ebook-lint/cmd/cbz/compress.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	filesize "github.com/pjkaufman/go-go-gadgets/ebook-lint/internal/file-size"
-	"github.com/pjkaufman/go-go-gadgets/ebook-lint/internal/images"
 	filehandler "github.com/pjkaufman/go-go-gadgets/pkg/file-handler"
-	"github.com/pjkaufman/go-go-gadgets/pkg/image"
 	"github.com/pjkaufman/go-go-gadgets/pkg/logger"
 	"github.com/spf13/cobra"
 )
@@ -83,32 +81,20 @@ func init() {
 }
 
 func compressCbz(lintDir, cbz string) {
-	var src = filehandler.JoinPath(lintDir, cbz)
-	var dest = filehandler.JoinPath(lintDir, "cbz")
+	// var src = filehandler.JoinPath(lintDir, cbz)
+	// var dest = filehandler.JoinPath(lintDir, "cbz")
 
-	err := filehandler.UnzipRunOperationAndRezip(src, dest, func() error {
-		var imageFiles, err = filehandler.MustGetAllFilesWithExtsInASpecificFolderAndSubFolders(dest, image.CompressableImageExts...)
-		if err != nil {
-			return err
-		}
+	// filehandler.UnzipRunOperationAndRezip(src, dest, func() {
+	// 	var imageFiles = filehandler.MustGetAllFilesWithExtsInASpecificFolderAndSubFolders(dest, image.CompressableImageExts...)
 
-		for i, imageFile := range imageFiles {
-			if verbose {
-				logger.WriteInfof("%d of %d: compressing %q\n", i, len(imageFiles), imageFile)
-			}
+	// 	for i, imageFile := range imageFiles {
+	// 		if verbose {
+	// 			logger.WriteInfo(fmt.Sprintf(`%d of %d: compressing %q`, i, len(imageFiles), imageFile))
+	// 		}
 
-			err = images.CompressImage(imageFile)
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		logger.WriteError(err.Error())
-	}
+	// 		images.CompressImage(imageFile)
+	// 	}
+	// })
 }
 
 func ValidateCompressFlags(dir string) error {

--- a/ebook-lint/cmd/cbz/compress.go
+++ b/ebook-lint/cmd/cbz/compress.go
@@ -43,7 +43,7 @@ var compressCmd = &cobra.Command{
 
 		logger.WriteInfo("Started compressing all cbzs\n")
 
-		cbzs, err := filehandler.MustGetAllFilesWithExtInASpecificFolder(dir, ".cbz")
+		cbzs, err := filehandler.GetAllFilesWithExtInASpecificFolder(dir, ".cbz")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}
@@ -59,12 +59,12 @@ var compressCmd = &cobra.Command{
 
 			var originalFile = cbz + ".original"
 
-			newKbSize, err := filehandler.MustGetFileSize(filehandler.JoinPath(dir, cbz))
+			newKbSize, err := filehandler.GetFileSize(filehandler.JoinPath(dir, cbz))
 			if err != nil {
 				logger.WriteError(err.Error())
 			}
 
-			oldKbSize, err := filehandler.MustGetFileSize(filehandler.JoinPath(dir, originalFile))
+			oldKbSize, err := filehandler.GetFileSize(filehandler.JoinPath(dir, originalFile))
 			if err != nil {
 				logger.WriteError(err.Error())
 			}

--- a/ebook-lint/cmd/epub/check-for-manually-fxiable-issues.go
+++ b/ebook-lint/cmd/epub/check-for-manually-fxiable-issues.go
@@ -167,7 +167,7 @@ var fixableCmd = &cobra.Command{
 				contextBreak = logger.GetInputString("What is the section break for the epub?:")
 
 				if strings.TrimSpace(contextBreak) == "" {
-					return nil, errors.New("please provide a non-whitespace section break")
+					return nil, fmt.Errorf("please provide a non-whitespace section break")
 				}
 
 				/**
@@ -248,7 +248,7 @@ var fixableCmd = &cobra.Command{
 			return handleCssChanges(addCssSectionIfMissing, addCssPageIfMissing, opfFolder, cssFiles, contextBreak, zipFiles, w, handledFiles)
 		})
 		if err != nil {
-			logger.WriteError(fmt.Sprintf("failed to fix manually fixable issues for %q: %s", epubFile, err))
+			logger.WriteErrorf("failed to fix manually fixable issues for %q: %s", epubFile, err)
 		}
 
 		logger.WriteInfo("\nFinished showing manually fixable issues...")

--- a/ebook-lint/cmd/epub/check-for-manually-fxiable-issues.go
+++ b/ebook-lint/cmd/epub/check-for-manually-fxiable-issues.go
@@ -229,10 +229,6 @@ var fixableCmd = &cobra.Command{
 					}
 				}
 
-				if fileText == newText {
-					continue
-				}
-
 				err = filehandler.WriteZipCompressedString(w, filePath, newText)
 				if err != nil {
 					logger.WriteError(err.Error())

--- a/ebook-lint/cmd/epub/check-for-manually-fxiable-issues.go
+++ b/ebook-lint/cmd/epub/check-for-manually-fxiable-issues.go
@@ -141,7 +141,7 @@ var fixableCmd = &cobra.Command{
 			logger.WriteError(err.Error())
 		}
 
-		err = filehandler.FileMustExist(epubFile, "epub-file")
+		err = filehandler.FileArgExists(epubFile, "epub-file")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}

--- a/ebook-lint/cmd/epub/check-for-manually-fxiable-issues.go
+++ b/ebook-lint/cmd/epub/check-for-manually-fxiable-issues.go
@@ -146,115 +146,93 @@ var fixableCmd = &cobra.Command{
 
 		logger.WriteInfo("Started showing manually fixable issues...\n")
 
-		var epubFolder = filehandler.GetFileFolder(epubFile)
-		var dest = filehandler.JoinPath(epubFolder, "epub")
-		err = filehandler.UnzipRunOperationAndRezip(epubFile, dest, func() error {
-			opfFolder, epubInfo, err := getEpubInfo(dest, epubFile)
-			if err != nil {
-				return err
-			}
+		// var epubFolder = filehandler.GetFileFolder(epubFile)
+		// var dest = filehandler.JoinPath(epubFolder, "epub")
+		// filehandler.UnzipRunOperationAndRezip(epubFile, dest, func() {
+		// 	opfFolder, epubInfo := getEpubInfo(dest, epubFile)
+		// 	validateFilesExist(opfFolder, epubInfo.HtmlFiles)
+		// 	validateFilesExist(opfFolder, epubInfo.CssFiles)
 
-			err = validateFilesExist(opfFolder, epubInfo.HtmlFiles)
-			if err != nil {
-				return err
-			}
+		// 	var addCssSectionIfMissing bool = false
+		// 	var addCssPageIfMissing bool = false
+		// 	if runAll || runSectionBreak {
+		// 		contextBreak = logger.GetInputString("What is the section break for the epub?:")
 
-			err = validateFilesExist(opfFolder, epubInfo.CssFiles)
-			if err != nil {
-				return err
-			}
+		// 		if strings.TrimSpace(contextBreak) == "" {
+		// 			logger.WriteError("Please provide a non-whitespace section break")
+		// 		}
 
-			var addCssSectionIfMissing bool = false
-			var addCssPageIfMissing bool = false
-			if runAll || runSectionBreak {
-				contextBreak = logger.GetInputString("What is the section break for the epub?:")
+		// 		/**
+		// 		TODO: handle the scenario where the section break is an image
 
-				if strings.TrimSpace(contextBreak) == "" {
-					return fmt.Errorf("please provide a non-whitespace section break")
-				}
+		// 		Image Context Breaks
+		// 		To use an image:
 
-				/**
-				TODO: handle the scenario where the section break is an image
+		// 		In the CSS:
+		// 		hr.image {
+		// 		display:block;
+		// 		background: transparent url("images/sectionBreakImage.png") no-repeat center;
+		// 		height:2em;
+		// 		border:0;
+		// 		}
 
-				Image Context Breaks
-				To use an image:
+		// 		In the HTML:
+		// 		<hr class="image" />
+		// 		**/
+		// 	}
 
-				In the CSS:
-				hr.image {
-				display:block;
-				background: transparent url("images/sectionBreakImage.png") no-repeat center;
-				height:2em;
-				border:0;
-				}
+		// 	var cssFiles = make([]string, len(epubInfo.CssFiles))
+		// 	var i = 0
+		// 	for cssFile := range epubInfo.CssFiles {
+		// 		cssFiles[i] = cssFile
+		// 		i++
+		// 	}
 
-				In the HTML:
-				<hr class="image" />
-				**/
-			}
+		// 	if (runAll || runSectionBreak || runPageBreak) && len(cssFiles) == 0 {
+		// 		logger.WriteError(CssPathsEmptyWhenArgIsNeeded)
+		// 	}
 
-			var cssFiles = make([]string, len(epubInfo.CssFiles))
-			var i = 0
-			for cssFile := range epubInfo.CssFiles {
-				cssFiles[i] = cssFile
-				i++
-			}
+		// 	var saveAndQuit = false
+		// 	for file := range epubInfo.HtmlFiles {
+		// 		if saveAndQuit {
+		// 			break
+		// 		}
 
-			if (runAll || runSectionBreak || runPageBreak) && len(cssFiles) == 0 {
-				return fmt.Errorf(CssPathsEmptyWhenArgIsNeeded)
-			}
+		// 		var filePath = getFilePath(opfFolder, file)
+		// 		fileText := filehandler.ReadInFileContents(filePath)
 
-			var saveAndQuit = false
-			for file := range epubInfo.HtmlFiles {
-				if saveAndQuit {
-					break
-				}
+		// 		var newText = linter.CleanupHtmlSpacing(fileText)
 
-				var filePath = getFilePath(opfFolder, file)
-				fileText, err := filehandler.ReadInFileContents(filePath)
-				if err != nil {
-					return err
-				}
+		// 		for _, potentiallyFixableIssue := range potentiallyFixableIssues {
+		// 			if saveAndQuit {
+		// 				break
+		// 			}
 
-				var newText = linter.CleanupHtmlSpacing(fileText)
+		// 			if potentiallyFixableIssue.isEnabled == nil {
+		// 				logger.WriteError(fmt.Sprintf("%q is not properly setup to run as a potentially fixable rule since it has no boolean for isEnabled", potentiallyFixableIssue.name))
+		// 			}
 
-				for _, potentiallyFixableIssue := range potentiallyFixableIssues {
-					if saveAndQuit {
-						break
-					}
+		// 			if runAll || *potentiallyFixableIssue.isEnabled {
+		// 				suggestions := potentiallyFixableIssue.getSuggestions(newText)
 
-					if potentiallyFixableIssue.isEnabled == nil {
-						return fmt.Errorf("%q is not properly setup to run as a potentially fixable rule since it has no boolean for isEnabled", potentiallyFixableIssue.name)
-					}
+		// 				var updateMade bool
+		// 				newText, updateMade, saveAndQuit = promptAboutSuggestions(potentiallyFixableIssue.name, suggestions, newText, potentiallyFixableIssue.updateAllInstances)
 
-					if runAll || *potentiallyFixableIssue.isEnabled {
-						suggestions := potentiallyFixableIssue.getSuggestions(newText)
+		// 				if potentiallyFixableIssue.addCssIfMissing && updateMade {
+		// 					addCssSectionIfMissing = addCssSectionIfMissing || updateMade
+		// 				}
+		// 			}
+		// 		}
 
-						var updateMade bool
-						newText, updateMade, saveAndQuit = promptAboutSuggestions(potentiallyFixableIssue.name, suggestions, newText, potentiallyFixableIssue.updateAllInstances)
+		// 		if fileText == newText {
+		// 			continue
+		// 		}
 
-						if potentiallyFixableIssue.addCssIfMissing && updateMade {
-							addCssSectionIfMissing = addCssSectionIfMissing || updateMade
-						}
-					}
-				}
+		// 		filehandler.WriteFileContents(filePath, newText)
+		// 	}
 
-				if fileText == newText {
-					continue
-				}
-
-				err = filehandler.WriteFileContents(filePath, newText)
-				if err != nil {
-					return err
-				}
-			}
-
-			handleCssChanges(addCssSectionIfMissing, addCssPageIfMissing, opfFolder, cssFiles, contextBreak)
-
-			return nil
-		})
-		if err != nil {
-			logger.WriteError(err.Error())
-		}
+		// 	handleCssChanges(addCssSectionIfMissing, addCssPageIfMissing, opfFolder, cssFiles, contextBreak)
+		// })
 
 		logger.WriteInfo("\nFinished showing manually fixable issues...")
 	},

--- a/ebook-lint/cmd/epub/common.go
+++ b/ebook-lint/cmd/epub/common.go
@@ -46,7 +46,7 @@ var epubFile string
 // 	}
 // }
 
-func validateFilesExist(opfFolder string, files map[string]struct{}, zipFiles map[string]*zip.File) {
+func validateFilesExist(opfFolder string, files map[string]struct{}, zipFiles map[string]*zip.File) error {
 	for file := range files {
 		var filePath = getFilePath(opfFolder, file)
 

--- a/ebook-lint/cmd/epub/common.go
+++ b/ebook-lint/cmd/epub/common.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pjkaufman/go-go-gadgets/pkg/logger"
 )
 
 const (
@@ -17,41 +15,12 @@ const (
 
 var epubFile string
 
-// func getEpubInfo(dir, epubName string) (string, linter.EpubInfo) {
-// 	opfFiles := filehandler.MustGetAllFilesWithExtsInASpecificFolderAndSubFolders(dir, ".opf")
-// 	if len(opfFiles) < 1 {
-// 		logger.WriteError(fmt.Sprintf("did not find opf file for %q", epubName))
-// 	}
-
-// 	var opfFile = opfFiles[0]
-// 	opfText := filehandler.ReadInFileContents(opfFile)
-
-// 	epubInfo, err := linter.ParseOpfFile(opfText)
-// 	if err != nil {
-// 		logger.WriteError(fmt.Sprintf("Failed to parse %q for %q: %s", opfFile, epubName, err))
-// 	}
-
-// 	var opfFolder = filehandler.GetFileFolder(opfFile)
-
-// 	return opfFolder, epubInfo
-// }
-
-// func validateFilesExist(opfFolder string, files map[string]struct{}) {
-// 	for file := range files {
-// 		var filePath = getFilePath(opfFolder, file)
-
-// 		if !filehandler.FileExists(filePath) {
-// 			logger.WriteError(fmt.Sprintf(`file from manifest not found: %q must exist`, filePath))
-// 		}
-// 	}
-// }
-
 func validateFilesExist(opfFolder string, files map[string]struct{}, zipFiles map[string]*zip.File) error {
 	for file := range files {
 		var filePath = getFilePath(opfFolder, file)
 
 		if _, ok := zipFiles[filePath]; !ok {
-			logger.WriteError(fmt.Sprintf(`file from manifest not found: %q must exist`, filePath))
+			return fmt.Errorf(`file from manifest not found: %q must exist`, filePath)
 		}
 	}
 

--- a/ebook-lint/cmd/epub/compress-and-lint.go
+++ b/ebook-lint/cmd/epub/compress-and-lint.go
@@ -102,8 +102,6 @@ func init() {
 
 func LintEpub(lintDir, epub string, runCompressImages bool) error {
 	var src = filehandler.JoinPath(lintDir, epub)
-	// var dest = filehandler.JoinPath(lintDir, "epub")
-
 	err := epubhandler.UpdateEpub(src, func(zipFiles map[string]*zip.File, w *zip.Writer, epubInfo epubhandler.EpubInfo, opfFolder string) []string {
 		validateFilesExist(opfFolder, epubInfo.HtmlFiles, zipFiles)
 		validateFilesExist(opfFolder, epubInfo.ImagesFiles, zipFiles)
@@ -175,36 +173,6 @@ func LintEpub(lintDir, epub string, runCompressImages bool) error {
 	if err != nil {
 		logger.WriteError(fmt.Sprintf("failed to update epub %q: %s", src, err))
 	}
-
-	// filehandler.UnzipRunOperationAndRezip(src, dest, func() {
-	// 	opfFolder, epubInfo := getEpubInfo(dest, epub)
-
-	// validateFilesExist(opfFolder, epubInfo.HtmlFiles)
-	// validateFilesExist(opfFolder, epubInfo.ImagesFiles)
-	// validateFilesExist(opfFolder, epubInfo.OtherFiles)
-
-	// // fix up all xhtml files first
-	// for file := range epubInfo.HtmlFiles {
-	// 	var filePath = getFilePath(opfFolder, file)
-	// 	fileText := filehandler.ReadInFileContents(filePath)
-	// 	var newText = linter.EnsureEncodingIsPresent(fileText)
-	// 	newText = linter.CommonStringReplace(newText)
-
-	// 	newText = linter.EnsureLanguageIsSet(newText, lang)
-
-	// 	if fileText == newText {
-	// 		continue
-	// 	}
-
-	// 	filehandler.WriteFileContents(filePath, newText)
-	// }
-
-	// //TODO: get all files in the repo and prompt the user whether they want to delete them if they are not in the manifest
-
-	// if runCompressImages {
-	// 	images.CompressRelativeImages(opfFolder, epubInfo.ImagesFiles)
-	// }
-	// })
 }
 
 func ValidateCompressAndLintFlags(lintDir, lang string) error {

--- a/ebook-lint/cmd/epub/compress-and-lint.go
+++ b/ebook-lint/cmd/epub/compress-and-lint.go
@@ -55,7 +55,7 @@ var compressAndLintCmd = &cobra.Command{
 
 		logger.WriteInfo("Starting compression and linting for each epub\n")
 
-		epubs, err := filehandler.MustGetAllFilesWithExtInASpecificFolder(lintDir, ".epub")
+		epubs, err := filehandler.GetAllFilesWithExtInASpecificFolder(lintDir, ".epub")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}
@@ -70,12 +70,12 @@ var compressAndLintCmd = &cobra.Command{
 			}
 
 			var originalFile = epub + ".original"
-			newKbSize, err := filehandler.MustGetFileSize(epub)
+			newKbSize, err := filehandler.GetFileSize(epub)
 			if err != nil {
 				logger.WriteError(err.Error())
 			}
 
-			oldKbSize, err := filehandler.MustGetFileSize(originalFile)
+			oldKbSize, err := filehandler.GetFileSize(originalFile)
 			if err != nil {
 				logger.WriteError(err.Error())
 			}

--- a/ebook-lint/cmd/epub/compress-and-lint.go
+++ b/ebook-lint/cmd/epub/compress-and-lint.go
@@ -2,7 +2,6 @@ package epub
 
 import (
 	"archive/zip"
-	"bytes"
 	"errors"
 	"fmt"
 	"strings"
@@ -125,10 +124,6 @@ func LintEpub(lintDir, epub string, runCompressImages bool) error {
 
 			newText = linter.EnsureLanguageIsSet(newText, lang)
 
-			if fileText == newText {
-				continue
-			}
-
 			err = filehandler.WriteZipCompressedString(w, filePath, newText)
 			if err != nil {
 				logger.WriteError(err.Error())
@@ -155,10 +150,6 @@ func LintEpub(lintDir, epub string, runCompressImages bool) error {
 					logger.WriteError(err.Error())
 				}
 
-				if bytes.Equal(data, newData) {
-					continue
-				}
-
 				err = filehandler.WriteZipCompressedBytes(w, filePath, newData)
 				if err != nil {
 					logger.WriteError(err.Error())
@@ -170,9 +161,12 @@ func LintEpub(lintDir, epub string, runCompressImages bool) error {
 
 		return handledFiles
 	})
+
 	if err != nil {
-		logger.WriteError(fmt.Sprintf("failed to update epub %q: %s", src, err))
+		return fmt.Errorf("failed to update epub %q: %s", src, err)
 	}
+
+	return nil
 }
 
 func ValidateCompressAndLintFlags(lintDir, lang string) error {

--- a/ebook-lint/cmd/epub/replace-strings.go
+++ b/ebook-lint/cmd/epub/replace-strings.go
@@ -68,7 +68,7 @@ var replaceStringsCmd = &cobra.Command{
 			logger.WriteError(err.Error())
 		}
 
-		err = epubhandler.UpdateEpub(epubFile, func(zipFiles map[string]*zip.File, w *zip.Writer, epubInfo epubhandler.EpubInfo, opfFolder string) []string {
+		err = epubhandler.UpdateEpub(epubFile, func(zipFiles map[string]*zip.File, w *zip.Writer, epubInfo epubhandler.EpubInfo, opfFolder string) ([]string, error) {
 			validateFilesExist(opfFolder, epubInfo.HtmlFiles, zipFiles)
 
 			var handledFiles []string
@@ -79,7 +79,7 @@ var replaceStringsCmd = &cobra.Command{
 
 				fileText, err := filehandler.ReadInZipFileContents(zipFile)
 				if err != nil {
-					logger.WriteError(err.Error())
+					return nil, err
 				}
 
 				var newText = linter.CommonStringReplace(fileText)
@@ -87,7 +87,7 @@ var replaceStringsCmd = &cobra.Command{
 
 				err = filehandler.WriteZipCompressedString(w, filePath, newText)
 				if err != nil {
-					logger.WriteError(err.Error())
+					return nil, err
 				}
 
 				handledFiles = append(handledFiles, filePath)
@@ -114,7 +114,7 @@ var replaceStringsCmd = &cobra.Command{
 			}
 
 			if len(failedReplaces) == 0 {
-				return handledFiles
+				return handledFiles, nil
 			}
 
 			logger.WriteWarn("\nFailed Replaces:")
@@ -122,7 +122,7 @@ var replaceStringsCmd = &cobra.Command{
 				logger.WriteWarn(fmt.Sprintf("%d. %s", i+1, failedReplace))
 			}
 
-			return handledFiles
+			return handledFiles, nil
 		})
 		if err != nil {
 			logger.WriteError(fmt.Sprintf("failed to replace strings in %q: %s", epubFile, err))

--- a/ebook-lint/cmd/epub/replace-strings.go
+++ b/ebook-lint/cmd/epub/replace-strings.go
@@ -45,12 +45,12 @@ var replaceStringsCmd = &cobra.Command{
 			logger.WriteError(err.Error())
 		}
 
-		err = filehandler.FileMustExist(epubFile, "epub-file")
+		err = filehandler.FileArgExists(epubFile, "epub-file")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}
 
-		err = filehandler.FileMustExist(extraReplacesFilePath, "extra-replace-file")
+		err = filehandler.FileArgExists(extraReplacesFilePath, "extra-replace-file")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}

--- a/ebook-lint/cmd/epub/replace-strings.go
+++ b/ebook-lint/cmd/epub/replace-strings.go
@@ -69,7 +69,10 @@ var replaceStringsCmd = &cobra.Command{
 		}
 
 		err = epubhandler.UpdateEpub(epubFile, func(zipFiles map[string]*zip.File, w *zip.Writer, epubInfo epubhandler.EpubInfo, opfFolder string) ([]string, error) {
-			validateFilesExist(opfFolder, epubInfo.HtmlFiles, zipFiles)
+			err = validateFilesExist(opfFolder, epubInfo.HtmlFiles, zipFiles)
+			if err != nil {
+				return nil, err
+			}
 
 			var handledFiles []string
 
@@ -119,13 +122,13 @@ var replaceStringsCmd = &cobra.Command{
 
 			logger.WriteWarn("\nFailed Replaces:")
 			for i, failedReplace := range failedReplaces {
-				logger.WriteWarn(fmt.Sprintf("%d. %s", i+1, failedReplace))
+				logger.WriteWarnf("%d. %s", i+1, failedReplace)
 			}
 
 			return handledFiles, nil
 		})
 		if err != nil {
-			logger.WriteError(fmt.Sprintf("failed to replace strings in %q: %s", epubFile, err))
+			logger.WriteErrorf("failed to replace strings in %q: %s", epubFile, err)
 		}
 
 		logger.WriteInfo("\nFinished epub string replacement...")

--- a/ebook-lint/cmd/epub/replace-strings.go
+++ b/ebook-lint/cmd/epub/replace-strings.go
@@ -2,11 +2,9 @@ package epub
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/pjkaufman/go-go-gadgets/ebook-lint/internal/linter"
 	filehandler "github.com/pjkaufman/go-go-gadgets/pkg/file-handler"
 	"github.com/pjkaufman/go-go-gadgets/pkg/logger"
 	"github.com/spf13/cobra"
@@ -55,84 +53,58 @@ var replaceStringsCmd = &cobra.Command{
 
 		logger.WriteInfo("Starting epub string replacement...\n")
 
-		var numHits = make(map[string]int)
-		extraReplaceContents, err := filehandler.ReadInFileContents(extraReplacesFilePath)
-		if err != nil {
-			logger.WriteError(err.Error())
-		}
+		// var numHits = make(map[string]int)
+		// var extraTextReplacements = linter.ParseTextReplacements(filehandler.ReadInFileContents(extraReplacesFilePath))
 
-		extraTextReplacements, err := linter.ParseTextReplacements(extraReplaceContents)
-		if err != nil {
-			logger.WriteError(err.Error())
-		}
+		// var epubFolder = filehandler.GetFileFolder(epubFile)
+		// var dest = filehandler.JoinPath(epubFolder, "epub")
+		// filehandler.UnzipRunOperationAndRezip(epubFile, dest, func() {
+		// 	opfFolder, epubInfo := getEpubInfo(dest, epubFile)
+		// 	validateFilesExist(opfFolder, epubInfo.HtmlFiles)
 
-		var epubFolder = filehandler.GetFileFolder(epubFile)
-		var dest = filehandler.JoinPath(epubFolder, "epub")
-		err = filehandler.UnzipRunOperationAndRezip(epubFile, dest, func() error {
-			opfFolder, epubInfo, err := getEpubInfo(dest, epubFile)
-			if err != nil {
-				return err
-			}
+		// 	for file := range epubInfo.HtmlFiles {
+		// 		var filePath = getFilePath(opfFolder, file)
+		// 		fileText := filehandler.ReadInFileContents(filePath)
 
-			err = validateFilesExist(opfFolder, epubInfo.HtmlFiles)
-			if err != nil {
-				return err
-			}
+		// 		var newText = linter.CommonStringReplace(fileText)
+		// 		newText = linter.ExtraStringReplace(newText, extraTextReplacements, numHits)
 
-			for file := range epubInfo.HtmlFiles {
-				var filePath = getFilePath(opfFolder, file)
-				fileText, err := filehandler.ReadInFileContents(filePath)
-				if err != nil {
-					return err
-				}
+		// 		if fileText == newText {
+		// 			continue
+		// 		}
 
-				var newText = linter.CommonStringReplace(fileText)
-				newText = linter.ExtraStringReplace(newText, extraTextReplacements, numHits)
+		// 		filehandler.WriteFileContents(filePath, newText)
+		// 	}
 
-				if fileText == newText {
-					continue
-				}
+		// 	var successfulReplaces []string
+		// 	var failedReplaces []string
+		// 	for searchText, hits := range numHits {
+		// 		if hits == 0 {
+		// 			failedReplaces = append(failedReplaces, searchText)
+		// 		} else {
+		// 			var timeText = "time"
+		// 			if hits > 1 {
+		// 				timeText += "s"
+		// 			}
 
-				err = filehandler.WriteFileContents(filePath, newText)
-				if err != nil {
-					return err
-				}
-			}
+		// 			successfulReplaces = append(successfulReplaces, fmt.Sprintf("`%s` was replaced %d %s", searchText, hits, timeText))
+		// 		}
+		// 	}
 
-			var successfulReplaces []string
-			var failedReplaces []string
-			for searchText, hits := range numHits {
-				if hits == 0 {
-					failedReplaces = append(failedReplaces, searchText)
-				} else {
-					var timeText = "time"
-					if hits > 1 {
-						timeText += "s"
-					}
+		// 	logger.WriteInfo("Successful Replaces:")
+		// 	for _, successfulReplace := range successfulReplaces {
+		// 		logger.WriteInfo(successfulReplace)
+		// 	}
 
-					successfulReplaces = append(successfulReplaces, fmt.Sprintf("`%s` was replaced %d %s", searchText, hits, timeText))
-				}
-			}
+		// 	if len(failedReplaces) == 0 {
+		// 		return
+		// 	}
 
-			logger.WriteInfo("Successful Replaces:")
-			for _, successfulReplace := range successfulReplaces {
-				logger.WriteInfo(successfulReplace)
-			}
-
-			if len(failedReplaces) == 0 {
-				return nil
-			}
-
-			logger.WriteWarn("\nFailed Replaces:")
-			for i, failedReplace := range failedReplaces {
-				logger.WriteWarnf("%d. %s\n", i+1, failedReplace)
-			}
-
-			return nil
-		})
-		if err != nil {
-			logger.WriteError(err.Error())
-		}
+		// 	logger.WriteWarn("\nFailed Replaces:")
+		// 	for i, failedReplace := range failedReplaces {
+		// 		logger.WriteWarn(fmt.Sprintf("%d. %s", i+1, failedReplace))
+		// 	}
+		// })
 
 		logger.WriteInfo("\nFinished epub string replacement...")
 	},

--- a/ebook-lint/internal/epub-handler/parse-opf-contents.go
+++ b/ebook-lint/internal/epub-handler/parse-opf-contents.go
@@ -1,4 +1,4 @@
-package linter
+package epubhandler
 
 import (
 	"encoding/xml"

--- a/ebook-lint/internal/epub-handler/parse-opf-contents_test.go
+++ b/ebook-lint/internal/epub-handler/parse-opf-contents_test.go
@@ -1,18 +1,18 @@
 //go:build unit
 
-package linter_test
+package epubhandler_test
 
 import (
 	"strings"
 	"testing"
 
-	"github.com/pjkaufman/go-go-gadgets/ebook-lint/internal/linter"
+	epubhandler "github.com/pjkaufman/go-go-gadgets/ebook-lint/internal/epub-handler"
 	"github.com/stretchr/testify/assert"
 )
 
 type ParseOpfContentsTestCase struct {
 	InputText        string
-	ExpectedEpubInfo linter.EpubInfo
+	ExpectedEpubInfo epubhandler.EpubInfo
 	ExpectedErr      error
 	IsSyntaxError    bool
 }
@@ -356,11 +356,11 @@ var ParseOpfContentsTestCases = map[string]ParseOpfContentsTestCase{
 	},
 	"make sure that parsing an opf that does have a package tag, but no version info results in an error": {
 		InputText:   noVersionFile,
-		ExpectedErr: linter.ErrNoPackageInfo,
+		ExpectedErr: epubhandler.ErrNoPackageInfo,
 	},
 	"make sure that parsing an opf that does not have a manifest tag results in an error": {
 		InputText:   noManifestFile,
-		ExpectedErr: linter.ErrNoManifest,
+		ExpectedErr: epubhandler.ErrNoManifest,
 	},
 	"make sure that parsing an opf that does have a manifest tag, but no ending manifest tag results in an error": {
 		InputText:     noManifestEndFile,
@@ -368,11 +368,11 @@ var ParseOpfContentsTestCases = map[string]ParseOpfContentsTestCase{
 	},
 	"make sure that parsing an opf that does have a manifest tag, but no list items in it results in an error": {
 		InputText:   noManifestContentsFile,
-		ExpectedErr: linter.ErrNoItemEls,
+		ExpectedErr: epubhandler.ErrNoItemEls,
 	},
 	"make sure that parsing an epub 2 has the proper version info and other package data": {
 		InputText: epub2PackageFile,
-		ExpectedEpubInfo: linter.EpubInfo{
+		ExpectedEpubInfo: epubhandler.EpubInfo{
 			HtmlFiles: map[string]struct{}{
 				"titlepage.xhtml":         {},
 				"chapter_1.html":          {},
@@ -418,7 +418,7 @@ var ParseOpfContentsTestCases = map[string]ParseOpfContentsTestCase{
 	},
 	"make sure that parsing an epub 3 has the proper version info and other package data": {
 		InputText: epub3PackageFile,
-		ExpectedEpubInfo: linter.EpubInfo{
+		ExpectedEpubInfo: epubhandler.EpubInfo{
 			HtmlFiles: map[string]struct{}{
 				"Text/CoverPage.html":       {},
 				"Text/TableOfContents.html": {},
@@ -559,13 +559,13 @@ var ParseOpfContentsTestCases = map[string]ParseOpfContentsTestCase{
 func TestParseOpfContents(t *testing.T) {
 	for name, args := range ParseOpfContentsTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual, err := linter.ParseOpfFile(args.InputText)
+			actual, err := epubhandler.ParseOpfFile(args.InputText)
 
 			if !args.IsSyntaxError {
 				assert.Equal(t, args.ExpectedErr, err)
 			} else {
 				assert.NotNil(t, err)
-				assert.True(t, strings.HasPrefix(err.Error(), linter.ErrorParsingXmlMessageStart), "A syntax error must start with the syntax error prefix")
+				assert.True(t, strings.HasPrefix(err.Error(), epubhandler.ErrorParsingXmlMessageStart), "A syntax error must start with the syntax error prefix")
 			}
 
 			if err == nil {

--- a/ebook-lint/internal/epub-handler/parse-opf-contents_test.go
+++ b/ebook-lint/internal/epub-handler/parse-opf-contents_test.go
@@ -476,7 +476,7 @@ var ParseOpfContentsTestCases = map[string]ParseOpfContentsTestCase{
 	},
 	"make sure that parsing package data that is html encoded is properly decoded": {
 		InputText: htmlEncodedOpf,
-		ExpectedEpubInfo: linter.EpubInfo{
+		ExpectedEpubInfo: epubhandler.EpubInfo{
 			HtmlFiles: map[string]struct{}{
 				"Text/titlepage.xhtml":                                {},
 				"Text/CR!7CKFN04Q4549HBHEWBBCHT72KYXP_split_000.html": {},

--- a/ebook-lint/internal/epub-handler/update-epub.go
+++ b/ebook-lint/internal/epub-handler/update-epub.go
@@ -107,8 +107,15 @@ func UpdateEpub(src string, operation func(map[string]*zip.File, *zip.Writer, Ep
 		return fmt.Errorf("failed to close zip reader: %w", err)
 	}
 
-	filehandler.MustRename(src, src+".original")
-	filehandler.MustRename(tempEpub, src)
+	err = filehandler.Rename(src, src+".original")
+	if err != nil {
+		return err
+	}
+
+	err = filehandler.Rename(tempEpub, src)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/ebook-lint/internal/epub-handler/update-epub.go
+++ b/ebook-lint/internal/epub-handler/update-epub.go
@@ -1,0 +1,101 @@
+package epubhandler
+
+import (
+	"archive/zip"
+	"fmt"
+	"os"
+	"strings"
+
+	filehandler "github.com/pjkaufman/go-go-gadgets/pkg/file-handler"
+	"github.com/pjkaufman/go-go-gadgets/pkg/logger"
+)
+
+func UpdateEpub(src string, operation func(map[string]*zip.File, *zip.Writer, EpubInfo, string) []string) error {
+	zipFiles, err := filehandler.GetFilesFromZip(src)
+	if err != nil {
+		return fmt.Errorf(fmt.Sprintf("failed to get zip contents for %q: %s", src, err))
+	}
+
+	var (
+		opfFilename string
+		opfFile     *zip.File
+	)
+	for filename, file := range zipFiles {
+		if strings.HasSuffix(filename, "opf") {
+			opfFilename = filename
+			opfFile = file
+			break
+		}
+	}
+
+	if opfFile == nil {
+		return fmt.Errorf("failed to find the opf file for %q", src)
+	}
+
+	fileContents, err := filehandler.ReadInZipFileContents(opfFile)
+	if err != nil {
+		return err
+	}
+
+	epubInfo, err := ParseOpfFile(fileContents)
+	if err != nil {
+		logger.WriteError(fmt.Sprintf("Failed to parse %q for %q: %s", opfFilename, src, err))
+	}
+	var opfFolder = filehandler.GetFileFolder(opfFilename)
+
+	var tempEpub = src + ".temp"
+	var runOperation = func() error {
+		tempEpubFile, err := os.Create(tempEpub)
+		if err != nil {
+			return fmt.Errorf("failed to create temporary epub file %q for %q: %w", tempEpub, src, err)
+		}
+
+		defer tempEpubFile.Close()
+
+		w := zip.NewWriter(tempEpubFile)
+		defer w.Close()
+
+		if mimetypeFile, ok := zipFiles["mimetype"]; ok {
+			err = filehandler.WriteZipUncompressedFile(w, mimetypeFile)
+			if err != nil {
+				return fmt.Errorf("failed to copy mimetype to zip file")
+			}
+		} else {
+			return fmt.Errorf("no mimetype exists for %q", src)
+		}
+
+		filesHandled := operation(zipFiles, w, epubInfo, opfFolder)
+
+		var handled bool
+		for filename, zipFile := range zipFiles {
+			handled = false
+			for _, handledFile := range filesHandled {
+				if filename == handledFile {
+					handled = true
+					break
+				}
+			}
+
+			if handled {
+				continue
+			}
+
+			err = filehandler.WriteZipCompressedFile(w, zipFile)
+			if err != nil {
+				return fmt.Errorf("failed to write file %q to zip for %q", zipFile.Name, src)
+			}
+		}
+
+		return nil
+	}
+
+	err = runOperation()
+	if err != nil {
+		return err
+	}
+
+	filehandler.MustRename(src, src+".original")
+	filehandler.MustRename(tempEpub, src)
+
+	return nil
+}

--- a/ebook-lint/internal/images/compress-image.go
+++ b/ebook-lint/internal/images/compress-image.go
@@ -17,9 +17,11 @@ func CompressImage(filePath string, data []byte) ([]byte, error) {
 		return data, nil
 	}
 
-	var newData []byte
-
-	var isPng = strings.HasSuffix(filePath, ".png")
+	var (
+		newData []byte
+		isPng   = strings.HasSuffix(filePath, ".png")
+		err     error
+	)
 	if isPng {
 		newData, err = image.PngRemoveExifData(data)
 	} else {

--- a/ebook-lint/internal/images/compress-image.go
+++ b/ebook-lint/internal/images/compress-image.go
@@ -1,37 +1,23 @@
 package images
 
 import (
-	"bytes"
 	"strings"
 
-	filehandler "github.com/pjkaufman/go-go-gadgets/pkg/file-handler"
 	"github.com/pjkaufman/go-go-gadgets/pkg/image"
 )
 
 var (
-	width   int = 800
-	quality int = 40
+	width         int = 800
+	quality       int = 40
+	minimumKbSize     = 150
 )
 
-func CompressImage(filePath string) error {
-	if !isCompressableImage(filePath) {
-		return nil
-	}
-
-	fileSize, err := filehandler.MustGetFileSize(filePath)
-	if err != nil {
-		return err
-	}
-
-	if fileSize < 150 {
-		return nil
+func CompressImage(filePath string, data []byte) ([]byte, error) {
+	if !isCompressableImage(filePath) || len(data)/1024 <= minimumKbSize {
+		return data, nil
 	}
 
 	var newData []byte
-	data, err := filehandler.ReadInBinaryFileContents(filePath)
-	if err != nil {
-		return err
-	}
 
 	var isPng = strings.HasSuffix(filePath, ".png")
 	if isPng {
@@ -40,7 +26,7 @@ func CompressImage(filePath string) error {
 		newData, err = image.JpegRemoveExifData(data)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if isPng {
@@ -49,18 +35,10 @@ func CompressImage(filePath string) error {
 		newData, err = image.JpegResize(newData, width, &quality)
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if !bytes.Equal(data, newData) {
-		err = filehandler.WriteBinaryFileContents(filePath, newData)
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return newData, nil
 }
 
 func isCompressableImage(imagePath string) bool {

--- a/ebook-lint/internal/images/compress-images.go
+++ b/ebook-lint/internal/images/compress-images.go
@@ -1,17 +1,7 @@
 package images
 
-import (
-	filehandler "github.com/pjkaufman/go-go-gadgets/pkg/file-handler"
-)
-
-func CompressRelativeImages(baseFolder string, images map[string]struct{}) error {
-	for imagePath := range images {
-		err := CompressImage(filehandler.JoinPath(baseFolder, imagePath))
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
+// func CompressRelativeImages(baseFolder string, images map[string]struct{}) {
+// 	for imagePath := range images {
+// 		CompressImage(filehandler.JoinPath(baseFolder, imagePath))
+// 	}
+// }

--- a/ebook-lint/internal/images/compress-images.go
+++ b/ebook-lint/internal/images/compress-images.go
@@ -1,7 +1,0 @@
-package images
-
-// func CompressRelativeImages(baseFolder string, images map[string]struct{}) {
-// 	for imagePath := range images {
-// 		CompressImage(filehandler.JoinPath(baseFolder, imagePath))
-// 	}
-// }

--- a/ebook-lint/internal/zip-handler/update-zip.go
+++ b/ebook-lint/internal/zip-handler/update-zip.go
@@ -8,7 +8,7 @@ import (
 	filehandler "github.com/pjkaufman/go-go-gadgets/pkg/file-handler"
 )
 
-func UpdateZip(src string, operation func(map[string]*zip.File, *zip.Writer) []string) error {
+func UpdateZip(src string, operation func(map[string]*zip.File, *zip.Writer) ([]string, error)) error {
 	r, zipFiles, err := filehandler.GetFilesFromZip(src)
 	if err != nil {
 		return fmt.Errorf("failed to get zip contents for %q: %w", src, err)
@@ -37,7 +37,11 @@ func UpdateZip(src string, operation func(map[string]*zip.File, *zip.Writer) []s
 			return fmt.Errorf("no mimetype exists for %q", src)
 		}
 
-		filesHandled := operation(zipFiles, w)
+		filesHandled, err := operation(zipFiles, w)
+		if err != nil {
+			return err
+		}
+
 		filesHandled = append(filesHandled, "mimetype")
 
 		var handled bool

--- a/ebook-lint/internal/zip-handler/update-zip.go
+++ b/ebook-lint/internal/zip-handler/update-zip.go
@@ -78,8 +78,15 @@ func UpdateZip(src string, operation func(map[string]*zip.File, *zip.Writer) ([]
 		return fmt.Errorf("failed to close zip reader: %w", err)
 	}
 
-	filehandler.MustRename(src, src+".original")
-	filehandler.MustRename(tempZip, src)
+	err = filehandler.Rename(src, src+".original")
+	if err != nil {
+		return err
+	}
+
+	err = filehandler.Rename(tempZip, src)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/git-helper/cmd/submodule-create.go
+++ b/git-helper/cmd/submodule-create.go
@@ -49,7 +49,7 @@ var createCmd = &cobra.Command{
 			logger.WriteError(err.Error())
 		}
 
-		err = filehandler.FolderMustExist(repoFolderPath, "repo-parent-path")
+		err = filehandler.FolderArgExists(repoFolderPath, "repo-parent-path")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}

--- a/git-helper/cmd/submodule-update.go
+++ b/git-helper/cmd/submodule-update.go
@@ -22,7 +22,7 @@ var updateCmd = &cobra.Command{
 			logger.WriteError(err.Error())
 		}
 
-		err = filehandler.FolderMustExist(repoFolderPath, "repo-parent-path")
+		err = filehandler.FolderArgExists(repoFolderPath, "repo-parent-path")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}

--- a/jp-proc/cmd/proc.go
+++ b/jp-proc/cmd/proc.go
@@ -29,7 +29,7 @@ var procCmd = &cobra.Command{
 			logger.WriteError(err.Error())
 		}
 
-		err = filehandler.FileMustExist(file, "file")
+		err = filehandler.FileArgExists(file, "file")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}

--- a/magnum/internal/config/config-handler.go
+++ b/magnum/internal/config/config-handler.go
@@ -19,7 +19,7 @@ func WriteConfig(config *Config) {
 	}
 
 	configDir := getConfigLocation()
-	err := filehandler.MustCreateFolderIfNotExists(configDir)
+	err := filehandler.CreateFolderIfNotExists(configDir)
 	if err != nil {
 		logger.WriteError(err.Error())
 	}

--- a/pkg/cmd-handler/add-generate-cmd.go
+++ b/pkg/cmd-handler/add-generate-cmd.go
@@ -40,7 +40,7 @@ func AddGenerateCmd(rootCmd *cobra.Command, title, description string, todos []s
 				logger.WriteError(err.Error())
 			}
 
-			err = filehandler.FolderMustExist(generationDir, "generation-dir")
+			err = filehandler.FolderArgExists(generationDir, "generation-dir")
 			if err != nil {
 				logger.WriteError(err.Error())
 			}

--- a/pkg/file-handler/file-handler.go
+++ b/pkg/file-handler/file-handler.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 )
 
@@ -32,7 +31,7 @@ func FileExists(path string) (bool, error) {
 	return true, nil
 }
 
-func FileMustExist(path, name string) error {
+func FileArgExists(path, name string) error {
 	if strings.TrimSpace(path) == "" {
 		return fmt.Errorf("%s must have a non-whitespace value", name)
 	}
@@ -70,7 +69,7 @@ func FolderExists(path string) (bool, error) {
 	return true, nil
 }
 
-func FolderMustExist(path, name string) error {
+func FolderArgExists(path, name string) error {
 	if strings.TrimSpace(path) == "" {
 		return fmt.Errorf("%s must have a non-whitespace value", name)
 	}
@@ -203,7 +202,7 @@ func WriteBinaryFileContents(path string, content []byte) error {
 	return nil
 }
 
-func MustGetAllFilesWithExtInASpecificFolder(dir, ext string) ([]string, error) {
+func GetAllFilesWithExtInASpecificFolder(dir, ext string) ([]string, error) {
 	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf(`failed to read in folder %q: %w`, dir, err)
@@ -219,43 +218,7 @@ func MustGetAllFilesWithExtInASpecificFolder(dir, ext string) ([]string, error) 
 	return fileList, nil
 }
 
-// based on https://stackoverflow.com/a/67629473
-func MustGetAllFilesWithExtsInASpecificFolderAndSubFolders(dir string, exts ...string) ([]string, error) {
-	var a []string
-	err := filepath.WalkDir(dir, func(s string, d fs.DirEntry, e error) error {
-		if e != nil {
-			return e
-		}
-
-		var name = strings.ToLower(d.Name())
-		if len(exts) == 1 {
-			if strings.HasSuffix(name, exts[0]) {
-				a = append(a, s)
-			}
-		} else if fileHasOneOfExts(name, exts) {
-			a = append(a, s)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to walk dir %q: %w", dir, err)
-	}
-
-	return a, nil
-}
-
-func fileHasOneOfExts(fileName string, exts []string) bool {
-	for _, ext := range exts {
-		if strings.HasSuffix(fileName, ext) {
-			return true
-		}
-	}
-
-	return false
-}
-
-func MustRename(src, dest string) error {
+func Rename(src, dest string) error {
 	err := os.Rename(src, dest)
 
 	if err != nil {
@@ -265,7 +228,7 @@ func MustRename(src, dest string) error {
 	return nil
 }
 
-func MustGetFileSize(path string) (float64, error) {
+func GetFileSize(path string) (float64, error) {
 	if strings.TrimSpace(path) == "" {
 		return 0, fmt.Errorf("to get a file's size it must have a non-empty path")
 	}
@@ -282,7 +245,7 @@ func MustGetFileSize(path string) (float64, error) {
 	return float64(f.Size()) / bytesInAKiloByte, nil
 }
 
-func MustCreateFolderIfNotExists(path string) error {
+func CreateFolderIfNotExists(path string) error {
 	folderExists, err := FolderExists(path)
 	if err != nil {
 		return err

--- a/pkg/file-handler/zip.go
+++ b/pkg/file-handler/zip.go
@@ -3,160 +3,19 @@ package filehandler
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/sync/errgroup"
 )
 
 const (
-	tempZip = "compress.zip"
 	// have to use these or similar permissions to avoid permission denied errors in some cases
 	folderPerms fs.FileMode = 0755
 	numWorkers  int         = 5
 )
-
-// UnzipRunOperationAndRezip starts by deleting the destination directory if it exists,
-// then it goes ahead an unzips the contents into the destination directory
-// once that is done it runs the operation func on the destination folder
-// lastly it rezips the folder back to compress.zip
-func UnzipRunOperationAndRezip(src, dest string, operation func() error) error {
-	dest = filepath.Clean(dest)
-
-	err := os.RemoveAll(dest)
-	if err != nil {
-		return fmt.Errorf("failed to delete the destination directory %q: %w", dest, err)
-	}
-
-	err = Unzip(src, dest)
-	if err != nil {
-		return fmt.Errorf("failed to unzip %q: %w", src, err)
-	}
-
-	err = operation()
-	if err != nil {
-		return err
-	}
-
-	err = Rezip(dest, tempZip)
-	if err != nil {
-		return fmt.Errorf("failed to rezip content for source %q: %w", src, err)
-	}
-
-	err = os.RemoveAll(dest)
-	if err != nil {
-		return fmt.Errorf("failed to cleanup the destination directory %q: %w", dest, err)
-	}
-
-	err = MustRename(src, src+".original")
-	if err != nil {
-		return err
-	}
-
-	err = MustRename(tempZip, src)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Unzip is based on https://stackoverflow.com/a/24792688
-func Unzip(src, dest string) error {
-	r, err := zip.OpenReader(src)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		r.Close()
-	}()
-
-	err = os.MkdirAll(dest, folderPerms)
-	if err != nil {
-		return err
-	}
-
-	files := make(chan *zip.File, len(r.File))
-	g, ctx := errgroup.WithContext(context.Background())
-	for i := 0; i < numWorkers; i++ {
-		g.Go(func() error {
-			for {
-				select {
-				case file, ok := <-files:
-					if ok {
-						wErr := extractAndWriteFile(dest, file)
-
-						if wErr != nil {
-							return wErr
-						}
-					} else {
-						return nil
-					}
-				case <-ctx.Done():
-					return ctx.Err()
-				}
-			}
-		})
-	}
-
-	for _, f := range r.File {
-		files <- f
-	}
-
-	close(files)
-
-	return g.Wait()
-}
-
-func extractAndWriteFile(dest string, f *zip.File) error {
-	rc, err := f.Open()
-	if err != nil {
-		return err
-	}
-	defer func() {
-		rc.Close()
-	}()
-
-	path := filepath.Join(dest, f.Name)
-
-	// Check for ZipSlip (Directory traversal)
-	if !strings.HasPrefix(path, dest+string(os.PathSeparator)) {
-		return fmt.Errorf("illegal file path: %s", path)
-	}
-
-	if f.FileInfo().IsDir() {
-		err = os.MkdirAll(path, folderPerms)
-
-		if err != nil {
-			return err
-		}
-	} else {
-		err = os.MkdirAll(filepath.Dir(path), folderPerms)
-		if err != nil {
-			return err
-		}
-
-		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-		if err != nil {
-			return err
-		}
-		defer func() {
-			f.Close()
-		}()
-
-		_, err = io.Copy(f, rc)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // Rezip is based on https://stackoverflow.com/a/63233911
 func Rezip(src, dest string) error {
@@ -171,7 +30,7 @@ func Rezip(src, dest string) error {
 	defer w.Close()
 
 	var mimetypePath = src + string(os.PathSeparator) + "mimetype"
-	err = CopyMimetypeToZip(w, src, mimetypePath)
+	err = copyMimetypeToZip(w, src, mimetypePath)
 	if err != nil {
 		return err
 	}
@@ -227,7 +86,7 @@ func writeToZip(w *zip.Writer, src, path string) error {
 	return nil
 }
 
-func CopyMimetypeToZip(w *zip.Writer, src, path string) error {
+func copyMimetypeToZip(w *zip.Writer, src, path string) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return err

--- a/pkg/file-handler/zip.go
+++ b/pkg/file-handler/zip.go
@@ -307,10 +307,7 @@ func WriteZipCompressedFile(w *zip.Writer, zipFile *zip.File) error {
 
 func WriteZipCompressedBytes(w *zip.Writer, filename string, data []byte) error {
 	var reader = bytes.NewReader(data)
-	f, err := w.CreateHeader(&zip.FileHeader{
-		Name:   filename,
-		Method: zip.Store,
-	})
+	f, err := w.Create(filename)
 	if err != nil {
 		return err
 	}

--- a/song-converter/cmd/create-csv.go
+++ b/song-converter/cmd/create-csv.go
@@ -38,7 +38,7 @@ var createCsvCmd = &cobra.Command{
 			logger.WriteError(err.Error())
 		}
 
-		err = filehandler.FolderMustExist(stagingDir, "working-dir")
+		err = filehandler.FolderArgExists(stagingDir, "working-dir")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}
@@ -48,7 +48,7 @@ var createCsvCmd = &cobra.Command{
 			logger.WriteInfo("Converting Markdown files to csv")
 		}
 
-		files, err := filehandler.MustGetAllFilesWithExtInASpecificFolder(stagingDir, ".md")
+		files, err := filehandler.GetAllFilesWithExtInASpecificFolder(stagingDir, ".md")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}

--- a/song-converter/cmd/create-html.go
+++ b/song-converter/cmd/create-html.go
@@ -67,12 +67,12 @@ var CreateHtmlCmd = &cobra.Command{
 			logger.WriteError(err.Error())
 		}
 
-		err = filehandler.FolderMustExist(stagingDir, "working-dir")
+		err = filehandler.FolderArgExists(stagingDir, "working-dir")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}
 
-		err = filehandler.FileMustExist(coverInputFilePath, "cover-file")
+		err = filehandler.FileArgExists(coverInputFilePath, "cover-file")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}
@@ -96,7 +96,7 @@ var CreateHtmlCmd = &cobra.Command{
 			logger.WriteInfo("Converting Markdown files to html")
 		}
 
-		files, err := filehandler.MustGetAllFilesWithExtInASpecificFolder(stagingDir, ".md")
+		files, err := filehandler.GetAllFilesWithExtInASpecificFolder(stagingDir, ".md")
 		if err != nil {
 			logger.WriteError(err.Error())
 		}


### PR DESCRIPTION
Fixes #9 

When creating epub files, it makes sense to go ahead and not create a temporary file in order to make modifications and create a new epub.

Here is what the performance gains look like for a test I ran after all changes were said and done:
```
goos: linux
goarch: amd64
pkg: github.com/pjkaufman/go-go-gadgets/ebook-lint/cmd/epub
cpu: AMD Ryzen 5 3500U with Radeon Vega Mobile Gfx
           │ old2.0.txt  │          new2.0.txt          │
           │   sec/op    │   sec/op     vs base         │
LintEpub-8   179.7m ± 1%   160.1m ± 2%  -10.89% (n=100)
```

Todos:
- [x] Add functionality for CBZ image compression
- [x] Remove unused code
- [x] Retest and make sure performance improvements still stand