### PR TITLE
Fix Up Remove Link and Other Logic

### DIFF
--- a/ebook-lint/cmd/epub/auto-fix-validation-issues.go
+++ b/ebook-lint/cmd/epub/auto-fix-validation-issues.go
@@ -273,7 +273,7 @@ var autoFixValidationCmd = &cobra.Command{
 						continue
 					}
 
-					nameToUpdatedContents[opfFilename], err = linter.FixMissingUniqueIdentifierId(nameToUpdatedContents[opfFilename], nameToUpdatedContents[ncxFilename])
+					nameToUpdatedContents[opfFilename], err = linter.FixMissingUniqueIdentifierId(nameToUpdatedContents[opfFilename], message.Message[startIndex:startIndex+endIndex])
 					if err != nil {
 						return nil, err
 					}
@@ -282,7 +282,7 @@ var autoFixValidationCmd = &cobra.Command{
 						if strings.HasSuffix(location.Path, ".opf") {
 							nameToUpdatedContents[opfFilename] = linter.RemoveLinkId(nameToUpdatedContents[opfFilename], location.Line-1, location.Column-1)
 						} else if strings.HasSuffix(location.Path, ".ncx") {
-							nameToUpdatedContents[ncxFileContents] = linter.RemoveLinkId(nameToUpdatedContents[ncxFileContents], location.Line-1, location.Column-1)
+							nameToUpdatedContents[ncxFilename] = linter.RemoveLinkId(nameToUpdatedContents[ncxFilename], location.Line-1, location.Column-1)
 						} else {
 							if fileContents, ok := nameToUpdatedContents[location.Path]; ok {
 								nameToUpdatedContents[location.Path] = linter.RemoveLinkId(fileContents, location.Line-1, location.Column-1)

--- a/ebook-lint/internal/linter/remove-file-from-opf.go
+++ b/ebook-lint/internal/linter/remove-file-from-opf.go
@@ -2,11 +2,12 @@ package linter
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
 const (
-	spineStartTag = "<spine>"
+	spineStartTag = "<spine"
 	spineEndTag   = "</spine>"
 )
 
@@ -21,9 +22,9 @@ func RemoveFileFromOpf(opfContents, fileName string) (string, error) {
 	lines := strings.Split(manifestContent, "\n")
 	var fileID string
 	for i, line := range lines {
-		if strings.Contains(line, fmt.Sprintf(`href="%s"`, fileName)) {
+		if strings.Contains(line, fmt.Sprintf(`%s"`, fileName)) {
 			fileID = extractID(line)
-			lines = append(lines[:i], lines[i+1:]...)
+			lines = slices.Delete(lines, i, i+1)
 			break
 		}
 	}

--- a/ebook-lint/internal/linter/remove-file-from-opf.go
+++ b/ebook-lint/internal/linter/remove-file-from-opf.go
@@ -20,9 +20,13 @@ func RemoveFileFromOpf(opfContents, fileName string) (string, error) {
 	}
 
 	lines := strings.Split(manifestContent, "\n")
-	var fileID string
+	var (
+		fileID    string
+		endOfHref = fmt.Sprintf(`%s"`, fileName)
+	)
+
 	for i, line := range lines {
-		if strings.Contains(line, fmt.Sprintf(`%s"`, fileName)) {
+		if strings.Contains(line, endOfHref) {
 			fileID = extractID(line)
 			lines = slices.Delete(lines, i, i+1)
 			break

--- a/ebook-lint/internal/linter/remove-link-id.go
+++ b/ebook-lint/internal/linter/remove-link-id.go
@@ -1,0 +1,36 @@
+package linter
+
+import (
+	"fmt"
+	"strings"
+)
+
+func RemoveLinkId(fileContents string, lineToUpdate, startOfFragment int) string {
+	var lines = strings.Split(fileContents, "\n")
+	if len(lines) <= lineToUpdate {
+		fmt.Println("Bail on lines")
+		return fileContents
+	}
+
+	var indicatedLine = lines[lineToUpdate]
+	if len(indicatedLine) <= startOfFragment {
+		fmt.Println("Bail on chars")
+		return fileContents
+	}
+
+	// get the fragment
+	// TODO: make it tolerate single quotes as well
+	var (
+		endOfFragment    = startOfFragment + 1 + strings.Index(indicatedLine[startOfFragment+1:], "\"")
+		fragment         = indicatedLine[startOfFragment:endOfFragment]
+		idIndicatorStart = strings.Index(fragment, "#")
+	)
+	fmt.Println(endOfFragment, fragment, idIndicatorStart)
+	if idIndicatorStart == -1 {
+		return fileContents
+	}
+
+	lines[lineToUpdate] = indicatedLine[:startOfFragment] + fragment[:idIndicatorStart] + indicatedLine[endOfFragment:]
+
+	return strings.Join(lines, "\n")
+}

--- a/ebook-lint/internal/linter/remove-link-id.go
+++ b/ebook-lint/internal/linter/remove-link-id.go
@@ -6,12 +6,12 @@ import (
 
 func RemoveLinkId(fileContents string, lineToUpdate, startOfFragment int) string {
 	var lines = strings.Split(fileContents, "\n")
-	if len(lines) <= lineToUpdate {
+	if len(lines) < lineToUpdate {
 		return fileContents
 	}
 
 	var indicatedLine = lines[lineToUpdate]
-	if len(indicatedLine) <= startOfFragment {
+	if len(indicatedLine) < startOfFragment {
 		return fileContents
 	}
 

--- a/ebook-lint/internal/linter/remove-link-id_test.go
+++ b/ebook-lint/internal/linter/remove-link-id_test.go
@@ -1,0 +1,64 @@
+//go:build unit
+
+package linter_test
+
+import (
+	"testing"
+
+	"github.com/pjkaufman/go-go-gadgets/ebook-lint/internal/linter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveLinkId(t *testing.T) {
+	tests := []struct {
+		name            string
+		fileContents    string
+		lineToUpdate    int
+		startOfFragment int
+		expected        string
+	}{
+		{
+			name:            "Line number does not exist",
+			fileContents:    "line1\nline2\nline3",
+			lineToUpdate:    5,
+			startOfFragment: 0,
+			expected:        "line1\nline2\nline3",
+		},
+		{
+			name:            "Line has less characters than start of fragment",
+			fileContents:    "line1\nline2\nline3",
+			lineToUpdate:    1,
+			startOfFragment: 10,
+			expected:        "line1\nline2\nline3",
+		},
+		{
+			name: "Line has href with # in the link",
+			fileContents: `line1
+<a href="link#id">link</a>
+line3`,
+			lineToUpdate:    1,
+			startOfFragment: 9,
+			expected: `line1
+<a href="link">link</a>
+line3`,
+		},
+		{
+			name: "Line has href without # in the link",
+			fileContents: `line1
+<a href="link">link</a>
+line3`,
+			lineToUpdate:    1,
+			startOfFragment: 9,
+			expected: `line1
+<a href="link">link</a>
+line3`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := linter.RemoveLinkId(tt.fileContents, tt.lineToUpdate, tt.startOfFragment)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/ebook-lint/internal/linter/remove-link-id_test.go
+++ b/ebook-lint/internal/linter/remove-link-id_test.go
@@ -37,7 +37,7 @@ func TestRemoveLinkId(t *testing.T) {
 <a href="link#id">link</a>
 line3`,
 			lineToUpdate:    1,
-			startOfFragment: 9,
+			startOfFragment: 15,
 			expected: `line1
 <a href="link">link</a>
 line3`,
@@ -48,9 +48,31 @@ line3`,
 <a href="link">link</a>
 line3`,
 			lineToUpdate:    1,
-			startOfFragment: 9,
+			startOfFragment: 15,
 			expected: `line1
 <a href="link">link</a>
+line3`,
+		},
+		{
+			name: "Line has src without # in the link",
+			fileContents: `line1
+<content src="link"/>
+line3`,
+			lineToUpdate:    1,
+			startOfFragment: 20,
+			expected: `line1
+<content src="link"/>
+line3`,
+		},
+		{
+			name: "Line has src with # in the link",
+			fileContents: `line1
+<content src="link#id"/>
+line3`,
+			lineToUpdate:    1,
+			startOfFragment: 23,
+			expected: `line1
+<content src="link"/>
 line3`,
 		},
 	}


### PR DESCRIPTION
There are a couple of additions that will help fix up some logic and make it work better moving forward.

Bugs Fixed:
- Missing unique identifier was having the ncx file passed in instead of the id
- JNovels file identification was incorrect for the manifest entries
- Fixed spine identification in the opf file

Features added:
- Ability to remove invalid fragments when they have a `#` in them by stripping out the id reference