### PR TITLE
Epub Lint: Fix Error in Some Potential Issues Breaking Terminal Functionality

### DIFF
--- a/epub-lint/cmd/check-for-manually-fixable-issues.go
+++ b/epub-lint/cmd/check-for-manually-fixable-issues.go
@@ -60,7 +60,7 @@ var (
 		{
 			Name: "Potential Section Breaks",
 			// wrapper here allows calling the get potential section breaks logic without needing to change the function definition
-			GetSuggestions: func(text string) map[string]string {
+			GetSuggestions: func(text string) (map[string]string, error) {
 				return linter.GetPotentialSectionBreaks(text, contextBreak)
 			},
 			IsEnabled:                   &runSectionBreak,
@@ -485,7 +485,10 @@ func runCliEpubFixable() error {
 				}
 
 				if runAll || *potentiallyFixableIssue.IsEnabled {
-					suggestions := potentiallyFixableIssue.GetSuggestions(newText)
+					suggestions, err := potentiallyFixableIssue.GetSuggestions(newText)
+					if err != nil {
+						return nil, err
+					}
 
 					var updateMade bool
 					newText, updateMade, saveAndQuit = promptAboutSuggestions(potentiallyFixableIssue.Name, suggestions, newText, potentiallyFixableIssue.UpdateAllInstances)

--- a/epub-lint/internal/linter/get-potential-incorrect-single-quotes.go
+++ b/epub-lint/internal/linter/get-potential-incorrect-single-quotes.go
@@ -4,23 +4,21 @@ import (
 	"fmt"
 	"regexp"
 	"unicode"
-
-	"github.com/pjkaufman/go-go-gadgets/pkg/logger"
 )
 
 var paragraphsWithSingleQuotes = regexp.MustCompile(`(?m)^([\r\t\f\v ]*?<p[^\n>]*?>)([^\n]*?'[^\n]*?)(</p>)`)
 
-func GetPotentialIncorrectSingleQuotes(fileContent string) map[string]string {
+func GetPotentialIncorrectSingleQuotes(fileContent string) (map[string]string, error) {
 	var subMatches = paragraphsWithSingleQuotes.FindAllStringSubmatch(fileContent, -1)
 	var originalToSuggested = make(map[string]string, 0)
 	if len(subMatches) == 0 {
-		return originalToSuggested
+		return originalToSuggested, nil
 	}
 
 	for _, groups := range subMatches {
 		replacedSingleQuoteString, updateMade, err := convertQuotes(groups[2])
 		if err != nil {
-			logger.WriteErrorf("Failed to convert single quotes to double as needed on string %q: %s", groups[0], err)
+			return nil, fmt.Errorf("Failed to convert single quotes to double as needed on string %q: %s", groups[0], err)
 		}
 
 		if updateMade {
@@ -28,7 +26,7 @@ func GetPotentialIncorrectSingleQuotes(fileContent string) map[string]string {
 		}
 	}
 
-	return originalToSuggested
+	return originalToSuggested, nil
 }
 
 func convertQuotes(input string) (string, bool, error) {

--- a/epub-lint/internal/linter/get-potential-incorrect-single-quotes_test.go
+++ b/epub-lint/internal/linter/get-potential-incorrect-single-quotes_test.go
@@ -57,8 +57,9 @@ var getPotentialIncorrectSingleQuotesTestCases = map[string]getPotentialIncorrec
 func TestGetPotentialIncorrectSingleQuotes(t *testing.T) {
 	for name, args := range getPotentialIncorrectSingleQuotesTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := linter.GetPotentialIncorrectSingleQuotes(args.inputText)
+			actual, err := linter.GetPotentialIncorrectSingleQuotes(args.inputText)
 
+			assert.Nil(t, err)
 			assert.Equal(t, args.expectedSuggestions, actual)
 		})
 	}

--- a/epub-lint/internal/linter/get-potential-missing-oxford-commas.go
+++ b/epub-lint/internal/linter/get-potential-missing-oxford-commas.go
@@ -7,16 +7,16 @@ import (
 // missing oxford comma regex based on https://stackoverflow.com/questions/30006666/capture-a-list-of-words-that-doesnt-contain-an-oxford-comma/30006707#30006707
 var oxfordCommaRegex = regexp.MustCompile(`(?m)^([\r\t\f\v ]*?<p[^>\n]*?>[^\n]*?)(\w+)((,[\r\t\f\v ]*?\w+)+)([\r\t\f\v ]+)(and|or)([\r\t\f\v ]+\w+)([^\n]*?</p>)`)
 
-func GetPotentialMissingOxfordCommas(fileContent string) map[string]string {
+func GetPotentialMissingOxfordCommas(fileContent string) (map[string]string, error) {
 	var subMatches = oxfordCommaRegex.FindAllStringSubmatch(fileContent, -1)
 	var originalToSuggested = make(map[string]string, len(subMatches))
 	if len(subMatches) == 0 {
-		return originalToSuggested
+		return originalToSuggested, nil
 	}
 
 	for _, groups := range subMatches {
 		originalToSuggested[groups[0]] = groups[1] + groups[2] + groups[3] + "," + groups[5] + groups[6] + groups[7] + groups[8]
 	}
 
-	return originalToSuggested
+	return originalToSuggested, nil
 }

--- a/epub-lint/internal/linter/get-potential-missing-oxford-commas_test.go
+++ b/epub-lint/internal/linter/get-potential-missing-oxford-commas_test.go
@@ -39,8 +39,9 @@ var getPotentialMissingOxfordCommasTestCases = map[string]getPotentialMissingOxf
 func TestGetPotentialMissingOxfordCommas(t *testing.T) {
 	for name, args := range getPotentialMissingOxfordCommasTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := linter.GetPotentialMissingOxfordCommas(args.InputText)
+			actual, err := linter.GetPotentialMissingOxfordCommas(args.InputText)
 
+			assert.Nil(t, err)
 			assert.Equal(t, args.ExpectedSuggestions, actual)
 		})
 	}

--- a/epub-lint/internal/linter/get-potential-page-breaks.go
+++ b/epub-lint/internal/linter/get-potential-page-breaks.go
@@ -8,16 +8,16 @@ const PageBrakeEl = `<hr class="blankSpace" />`
 
 var emptyParagraphsOrDivs = regexp.MustCompile(`(?m)^([\r\t\f\v ]*?<(p|div)[^\n>]*?>)[\r\t\f\v ]*?(</(p|div)>)`)
 
-func GetPotentialPageBreaks(fileContent string) map[string]string {
+func GetPotentialPageBreaks(fileContent string) (map[string]string, error) {
 	var subMatches = emptyParagraphsOrDivs.FindAllStringSubmatch(fileContent, -1)
 	var originalToSuggested = make(map[string]string, len(subMatches))
 	if len(subMatches) == 0 {
-		return originalToSuggested
+		return originalToSuggested, nil
 	}
 
 	for _, groups := range subMatches {
 		originalToSuggested[groups[0]] = PageBrakeEl
 	}
 
-	return originalToSuggested
+	return originalToSuggested, nil
 }

--- a/epub-lint/internal/linter/get-potential-page-breaks_test.go
+++ b/epub-lint/internal/linter/get-potential-page-breaks_test.go
@@ -43,8 +43,9 @@ var getPotentialPageBreaksTestCases = map[string]getPotentialPageBreaksTestCase{
 func TestGetPotentialPageBreaks(t *testing.T) {
 	for name, args := range getPotentialPageBreaksTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := linter.GetPotentialPageBreaks(args.inputText)
+			actual, err := linter.GetPotentialPageBreaks(args.inputText)
 
+			assert.Nil(t, err)
 			assert.Equal(t, args.expectedSuggestions, actual)
 		})
 	}

--- a/epub-lint/internal/linter/get-potential-section-breaks.go
+++ b/epub-lint/internal/linter/get-potential-section-breaks.go
@@ -8,13 +8,13 @@ import (
 
 const SectionBreakEl = `<hr class="character" />`
 
-func GetPotentialSectionBreaks(fileContent, sectionBreakIndicator string) map[string]string {
+func GetPotentialSectionBreaks(fileContent, sectionBreakIndicator string) (map[string]string, error) {
 	var contextBreakRegex = regexp.MustCompile(fmt.Sprintf(`(?m)^([\r\t\f\v ]*?<p[^\n>]*?>([^\n])*?)%s(([^\n]*?)</p>)`, regexp.QuoteMeta(sectionBreakIndicator)))
 
 	var subMatches = contextBreakRegex.FindAllStringSubmatch(fileContent, -1)
 	var originalToSuggested = make(map[string]string, len(subMatches))
 	if len(subMatches) == 0 {
-		return originalToSuggested
+		return originalToSuggested, nil
 	}
 
 	for _, groups := range subMatches {
@@ -26,5 +26,5 @@ func GetPotentialSectionBreaks(fileContent, sectionBreakIndicator string) map[st
 		originalToSuggested[groups[0]] = replaceValue
 	}
 
-	return originalToSuggested
+	return originalToSuggested, nil
 }

--- a/epub-lint/internal/linter/get-potential-section-breaks_test.go
+++ b/epub-lint/internal/linter/get-potential-section-breaks_test.go
@@ -39,8 +39,9 @@ var getPotentialSectionBreaksTestCases = map[string]getPotentialSectionBreaksTes
 func TestGetPotentialSectionBreaks(t *testing.T) {
 	for name, args := range getPotentialSectionBreaksTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := linter.GetPotentialSectionBreaks(args.inputText, args.inputContextBreak)
+			actual, err := linter.GetPotentialSectionBreaks(args.inputText, args.inputContextBreak)
 
+			assert.Nil(t, err)
 			assert.Equal(t, args.expectedSuggestions, actual)
 		})
 	}

--- a/epub-lint/internal/linter/get-potential-square-bracket-conversation-instances.go
+++ b/epub-lint/internal/linter/get-potential-square-bracket-conversation-instances.go
@@ -4,16 +4,16 @@ import "regexp"
 
 var squareBracketConversationRegex = regexp.MustCompile(`(<p[^\n>]*?>[\r\t\f\v ]*?(<a[^>]*?></a>[\r\t\f\v ]*?)?)\[([^\n]*?)\]([\r\t\f\v ]*?</p>)`)
 
-func GetPotentialSquareBracketConversationInstances(fileContent string) map[string]string {
+func GetPotentialSquareBracketConversationInstances(fileContent string) (map[string]string, error) {
 	var subMatches = squareBracketConversationRegex.FindAllStringSubmatch(fileContent, -1)
 	var originalToSuggested = make(map[string]string, len(subMatches))
 	if len(subMatches) == 0 {
-		return originalToSuggested
+		return originalToSuggested, nil
 	}
 
 	for _, groups := range subMatches {
 		originalToSuggested[groups[0]] = groups[1] + `"` + groups[3] + `"` + groups[4]
 	}
 
-	return originalToSuggested
+	return originalToSuggested, nil
 }

--- a/epub-lint/internal/linter/get-potential-square-bracket-conversation-instances_test.go
+++ b/epub-lint/internal/linter/get-potential-square-bracket-conversation-instances_test.go
@@ -49,8 +49,9 @@ var getPotentialSquareBracketConversationInstancesTestCases = map[string]getPote
 func TestGetPotentialSquareBracketConversationInstances(t *testing.T) {
 	for name, args := range getPotentialSquareBracketConversationInstancesTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := linter.GetPotentialSquareBracketConversationInstances(args.inputText)
+			actual, err := linter.GetPotentialSquareBracketConversationInstances(args.inputText)
 
+			assert.Nil(t, err)
 			assert.Equal(t, args.expectedSuggestions, actual)
 		})
 	}

--- a/epub-lint/internal/linter/get-potential-square-bracket-necessary-words.go
+++ b/epub-lint/internal/linter/get-potential-square-bracket-necessary-words.go
@@ -10,11 +10,11 @@ var (
 	squareBracketContentRegex       = regexp.MustCompile(`\[([^\n\]]*?)\]`)
 )
 
-func GetPotentialSquareBracketNecessaryWords(fileContent string) map[string]string {
+func GetPotentialSquareBracketNecessaryWords(fileContent string) (map[string]string, error) {
 	var subMatches = squareBracketNecessaryWordRegex.FindAllStringSubmatch(fileContent, -1)
 	var originalToSuggested = make(map[string]string, len(subMatches))
 	if len(subMatches) == 0 {
-		return originalToSuggested
+		return originalToSuggested, nil
 	}
 
 	for _, groups := range subMatches {
@@ -43,5 +43,5 @@ func GetPotentialSquareBracketNecessaryWords(fileContent string) map[string]stri
 		originalToSuggested[groups[0]] = replaceValue
 	}
 
-	return originalToSuggested
+	return originalToSuggested, nil
 }

--- a/epub-lint/internal/linter/get-potential-square-bracket-necessary-words_test.go
+++ b/epub-lint/internal/linter/get-potential-square-bracket-necessary-words_test.go
@@ -54,8 +54,9 @@ var getPotentialSquareBracketNecessaryWordsTestCases = map[string]getPotentialSq
 func TestGetPotentialSquareBracketNecessaryWords(t *testing.T) {
 	for name, args := range getPotentialSquareBracketNecessaryWordsTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := linter.GetPotentialSquareBracketNecessaryWords(args.inputText)
+			actual, err := linter.GetPotentialSquareBracketNecessaryWords(args.inputText)
 
+			assert.Nil(t, err)
 			assert.Equal(t, args.expectedSuggestions, actual)
 		})
 	}

--- a/epub-lint/internal/linter/get-potential-thought-instances.go
+++ b/epub-lint/internal/linter/get-potential-thought-instances.go
@@ -8,11 +8,11 @@ import (
 var thoughtParagraphs = regexp.MustCompile(`(<p[^\n>]*?>[^\n(]*?)\(([^\n()]*?)\)([^\n]*?)(</p>)`)
 var parenthesesContent = regexp.MustCompile(`\(([^\n\)]*?)\)`)
 
-func GetPotentialThoughtInstances(fileContent string) map[string]string {
+func GetPotentialThoughtInstances(fileContent string) (map[string]string, error) {
 	var subMatches = thoughtParagraphs.FindAllStringSubmatch(fileContent, -1)
 	var originalToSuggested = make(map[string]string, len(subMatches))
 	if len(subMatches) == 0 {
-		return originalToSuggested
+		return originalToSuggested, nil
 	}
 
 	for _, groups := range subMatches {
@@ -35,5 +35,5 @@ func GetPotentialThoughtInstances(fileContent string) map[string]string {
 		originalToSuggested[groups[0]] = replaceValue
 	}
 
-	return originalToSuggested
+	return originalToSuggested, nil
 }

--- a/epub-lint/internal/linter/get-potential-thought-instances_test.go
+++ b/epub-lint/internal/linter/get-potential-thought-instances_test.go
@@ -46,8 +46,9 @@ var getPotentialThoughtInstancesTestCases = map[string]getPotentialThoughtInstan
 func TestGetPotentialThoughtInstances(t *testing.T) {
 	for name, args := range getPotentialThoughtInstancesTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := linter.GetPotentialThoughtInstances(args.inputText)
+			actual, err := linter.GetPotentialThoughtInstances(args.inputText)
 
+			assert.Nil(t, err)
 			assert.Equal(t, args.expectedSuggestions, actual)
 		})
 	}

--- a/epub-lint/internal/linter/get-potentially-broken-lines.go
+++ b/epub-lint/internal/linter/get-potentially-broken-lines.go
@@ -15,7 +15,7 @@ var unendedParagraphRegex = regexp.MustCompile(`((^|\n)[ \t]*<p[^>]*>)([^\n]*(Dr
 var paragraphsWithDoubleQuotes = regexp.MustCompile(`((^|\n)[ \t]*<p[^>]*>)([^\n]*)(")([^\n]*)(</p>)`)
 var paragraphsStartingWithLowercaseLetter = regexp.MustCompile(`((^|\n)[ \t]*<p[^>]*>)(\s*[a-z][^\n]*</p>)`)
 
-func GetPotentiallyBrokenLines(fileContent string) map[string]string {
+func GetPotentiallyBrokenLines(fileContent string) (map[string]string, error) {
 	var originalToSuggested = make(map[string]string)
 	var parsedLines = map[string]struct{}{}
 
@@ -23,7 +23,7 @@ func GetPotentiallyBrokenLines(fileContent string) map[string]string {
 	parseUnendedDoubleQuotes(fileContent, parsedLines, originalToSuggested)
 	parseParagraphsStartingWithLowercaseLetters(fileContent, parsedLines, originalToSuggested)
 
-	return originalToSuggested
+	return originalToSuggested, nil
 }
 
 func parseUnendedParagraphs(fileContent string, parsedLines map[string]struct{}, originalToSuggested map[string]string) {

--- a/epub-lint/internal/linter/get-potentially-broken-lines_test.go
+++ b/epub-lint/internal/linter/get-potentially-broken-lines_test.go
@@ -174,8 +174,9 @@ var getPotentiallyBrokenLinesTestCases = map[string]getPotentiallyBrokenLinesTes
 func TestGetPotentiallyBrokenLines(t *testing.T) {
 	for name, args := range getPotentiallyBrokenLinesTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := linter.GetPotentiallyBrokenLines(args.inputText)
+			actual, err := linter.GetPotentiallyBrokenLines(args.inputText)
 
+			assert.Nil(t, err)
 			assert.Equal(t, args.expectedSuggestions, actual)
 		})
 	}

--- a/epub-lint/internal/linter/get-potentially-lacking-subordinate-clause-instances.go
+++ b/epub-lint/internal/linter/get-potentially-lacking-subordinate-clause-instances.go
@@ -7,11 +7,11 @@ var (
 	subordinateClausesReplaceRegex = regexp.MustCompile(`(.*?,)\s*?(?:but|thus|therefore|furthermore|however)(.*)`)
 )
 
-func GetPotentiallyLackingSubordinateClauseInstances(fileContent string) map[string]string {
+func GetPotentiallyLackingSubordinateClauseInstances(fileContent string) (map[string]string, error) {
 	matches := subordinateClausesRegex.FindAllString(fileContent, -1)
 	originalToSuggested := make(map[string]string, len(matches))
 	if len(matches) == 0 {
-		return originalToSuggested
+		return originalToSuggested, nil
 	}
 
 	for _, match := range matches {
@@ -19,5 +19,5 @@ func GetPotentiallyLackingSubordinateClauseInstances(fileContent string) map[str
 		originalToSuggested[match] = suggestion
 	}
 
-	return originalToSuggested
+	return originalToSuggested, nil
 }

--- a/epub-lint/internal/linter/get-potentially-lacking-subordinate-clause-instances_test.go
+++ b/epub-lint/internal/linter/get-potentially-lacking-subordinate-clause-instances_test.go
@@ -448,8 +448,9 @@ var getPotentialAlthoughButInstancesTestCases = map[string]getPotentialAlthoughB
 func TestGetPotentialAlthoughButInstances(t *testing.T) {
 	for name, args := range getPotentialAlthoughButInstancesTestCases {
 		t.Run(name, func(t *testing.T) {
-			actual := linter.GetPotentiallyLackingSubordinateClauseInstances(args.inputText)
+			actual, err := linter.GetPotentiallyLackingSubordinateClauseInstances(args.inputText)
 
+			assert.Nil(t, err)
 			assert.Equal(t, args.expectedSuggestions, actual)
 		})
 	}

--- a/epub-lint/internal/potentially-fixable-issue/potentially-fixable-issue.go
+++ b/epub-lint/internal/potentially-fixable-issue/potentially-fixable-issue.go
@@ -2,7 +2,7 @@ package potentiallyfixableissue
 
 type PotentiallyFixableIssue struct {
 	Name                        string
-	GetSuggestions              func(string) map[string]string
+	GetSuggestions              func(string) (map[string]string, error)
 	IsEnabled                   *bool
 	UpdateAllInstances          bool
 	AddCssSectionBreakIfMissing bool

--- a/epub-lint/internal/ui/suggestions.go
+++ b/epub-lint/internal/ui/suggestions.go
@@ -294,9 +294,10 @@ func (m *FixableIssuesModel) setupForNextSuggestions() (tea.Cmd, error) {
 				return nil, nil
 			}
 
-			var (
-				suggestions = potentialFixableIssue.GetSuggestions(m.PotentiallyFixableIssuesInfo.FileSuggestionData[m.PotentiallyFixableIssuesInfo.currentFileIndex].Text)
-			)
+			suggestions, err := potentialFixableIssue.GetSuggestions(m.PotentiallyFixableIssuesInfo.FileSuggestionData[m.PotentiallyFixableIssuesInfo.currentFileIndex].Text)
+			if err != nil {
+				return nil, err
+			}
 
 			if m.logFile != nil {
 				fmt.Fprintf(m.logFile, "Possible fixable issue %q has %d suggestion(s) found\n", potentialFixableIssue.Name, len(suggestions))


### PR DESCRIPTION
Fixes #29 

There was an issue where running the TUI for fixable issues could make it so that the text the user input into the terminal would not show. This was caused by exiting before letting the TUI handle its cleanup. Returning the error back out and letting the TUI cleanup its logic allows for the terminal to be restored to a functional state while still showing the error and stopping immediately.