### PR TITLE
Epub-Lint: Fix Issue Where Pluralized Numbers Were Considered Single Quotes

### DIFF
--- a/epub-lint/internal/linter/get-potential-incorrect-single-quotes.go
+++ b/epub-lint/internal/linter/get-potential-incorrect-single-quotes.go
@@ -50,19 +50,22 @@ func convertQuotes(input string) (string, bool, error) {
 			isNextLetter := i < len(runes)-1 && unicode.IsLetter(runes[i+1])
 			isContraction := isPrevLetter && isNextLetter
 
+			isPrevDigit := i > 0 && unicode.IsDigit(runes[i-1])
 			isPrevS := i > 0 && (runes[i-1] == 's' || runes[i-1] == 'S')
 			isNextS := i < len(runes)-1 && (runes[i+1] == 's' || runes[i+1] == 'S')
 			isPrevWord := i > 0 && unicode.IsLetter(runes[i-1])
+
+			isPluralDigit := isPrevDigit && isNextS
 			// we will assume that no possesives show up inside a single quote as that gets hairy and is not valid
 			isPossessive := (isPrevS || (isPrevWord && isNextS)) && singleQuoteCount%2 == 0
 
-			if !isContraction && !isPossessive {
+			if !isContraction && !isPossessive && !isPluralDigit {
 				singleQuoteCount++
 			}
 
-			// TODO: does not work for 'Cause
+			// TODO: does not work for "'Cause" or "'em"
 			// If it's not a contraction, not a possessive, and not inside double quotes, convert to double quote
-			if !isContraction && !isPossessive && !insideDoubleQuotes {
+			if !isContraction && !isPossessive && !insideDoubleQuotes && !isPluralDigit {
 				runes[i] = '"'
 				updateMade = true
 			}

--- a/epub-lint/internal/linter/get-potential-incorrect-single-quotes_test.go
+++ b/epub-lint/internal/linter/get-potential-incorrect-single-quotes_test.go
@@ -52,6 +52,12 @@ var getPotentialIncorrectSingleQuotesTestCases = map[string]getPotentialIncorrec
 			`<p>He said, "Hello. Can you hear that?". He stalled to get read to use his 'special move'. He called out again, "Are you there?"</p>`: `<p>He said, "Hello. Can you hear that?". He stalled to get read to use his "special move". He called out again, "Are you there?"</p>`,
 		},
 	},
+	"make sure that a file with a pluralized number is not considered to be a single quote and does not cause a suggestion by itself": {
+		inputText: `	<p>Normally, simply drawing a weapon in front of the Emperor in court was a grave offense, to say nothing of actually offering violence to a member of the Imperial family. However, the court was currently paralyzed in the wake of the earthquake. The Praetorians who should have defended the Emperor and his household were missing. Since there was nobody to maintain order, the area before the throne was a sea of chaos.</p>
+  <p>Tomita, watching from the side, flicked his Type 64's fire selector to レ(automatic fire), while Kuribayashi inspected Tyuule and the black-haired girl on the ground.</p>
+  <p>"Are you alright?"</p>`,
+		expectedSuggestions: map[string]string{},
+	},
 }
 
 func TestGetPotentialIncorrectSingleQuotes(t *testing.T) {


### PR DESCRIPTION
Fixes #30 

There was an issue where something like `60's` would get considered to be a single quote. This would cause an error to get thrown if there were not 3 other single quotes present due to the mismatch of single quotes. This should now be fixed.