### PR TITLE
Better Validation Handling and Handle Duplicate Ids

### DIFF
--- a/epub-lint/README.md
+++ b/epub-lint/README.md
@@ -6,7 +6,6 @@ This is a program that helps lint and make updates to epubs.
 
 ## Supported File Types
 - testdata
-- tui
 
 ## TODOs
 - See about removing unused files and images when running epub linting
@@ -16,6 +15,7 @@ This is a program that helps lint and make updates to epubs.
 - [compress-and-lint](#compress-and-lint)
 - [fix-validation](#fix-validation)
 - [fixable](#fixable)
+- [notes](#notes)
 - [replace-strings](#replace-strings)
 - [validate](#validate)
 
@@ -54,7 +54,7 @@ epub-lint compress-and-lint
 
 ### fix-validation
 
-Uses the provided epub and EPUBCheck JSON output file to fix auto fixable auto fix issues. Here is a list of all of the error codes that are currently handled:
+Uses the provided epub and EPUBCheck output file to fix auto fixable auto fix issues. Here is a list of all of the error codes that are currently handled:
 - OPF-014: add scripted to the list of values in the properties attribute on the manifest item
 - OPF-015: remove scripted to the list of values in the properties attribute on the manifest item
 - NCX-001: fix discrepancy in identifier between the OPF and NCX files
@@ -73,17 +73,17 @@ Uses the provided epub and EPUBCheck JSON output file to fix auto fixable auto f
 | ---------- | --------- | ----------- | ---------- | ------------- | ----------- | ----------- |
 |  | cleanup-jnovels | whether or not to remove JNovels info if it is present |  | false | false |  |
 | f | file | the epub file to replace strings in | string |  | true | Should be a file with one of the following extensions: epub |
-|  | issue-file | the path to the file with the validation issues | string |  | true | Should be a file with one of the following extensions: json |
+|  | issue-file | the path to the file with the validation issues | string |  | true |  |
 
 #### Usage
 
 ``` bash
-epub-lint fix-validation -f test.epub --issue-file epubCheckOutput.json
-will read in the contents of the JSON file and try to fix any of the fixable
+epub-lint fix-validation -f test.epub --issue-file epubCheckOutput.txt
+will read in the contents of the file and try to fix any of the fixable
 validation issues
 
-epub-lint fix-validation -f test.epub --issue-file epubCheckOutput.json --cleanup-jnovels
-will read in the contents of the JSON file and try to fix any of the fixable
+epub-lint fix-validation -f test.epub --issue-file epubCheckOutput.txt --cleanup-jnovels
+will read in the contents of the file and try to fix any of the fixable
 validation issues as well as remove any jnovels specific files
 ```
 
@@ -152,6 +152,26 @@ epub-lint fixable -f test.epub --thoughts
 epub-lint fixable -f test.epub -oxford-commas --thoughts --necessary-words
 ```
 
+### notes
+
+Goes through all of the content files and looks for "TL Note:", "Translator's Note:", or "Note:"
+and moves any matches to their own file with bidirectional linking between the footnote and its reference location.
+It also adds an entry to the TOC and spine of the epub so the "tl_notes.xhtml" file is at the end of the file's contents.
+
+
+#### Flags
+
+| Short Name | Long Name | Description | Value Type | Default Value | Is Required | Other Notes |
+| ---------- | --------- | ----------- | ---------- | ------------- | ----------- | ----------- |
+| f | file | the epub file to move translator's notes to their own file in | string |  | true | Should be a file with one of the following extensions: epub |
+
+#### Usage
+
+``` bash
+Finds all translator's notes and moves them to their own file if present
+epub-lint notes -f test.epub
+```
+
 ### replace-strings
 
 Uses the provided epub and extra replace Markdown file to replace a common set of strings and any extra instances specified in the extra file replace. After all replacements are made, the original epub will be moved to a .original file and the new file will take the place of the old file. It will also print out the successful extra replacements with the number of replacements made followed by warnings for any extra strings that it tried to find and replace values for, but did not find any instances to replace.
@@ -189,7 +209,7 @@ If EPUBCheck is not installed, it will automatically download and install the la
 | Short Name | Long Name | Description | Value Type | Default Value | Is Required | Other Notes |
 | ---------- | --------- | ----------- | ---------- | ------------- | ----------- | ----------- |
 | f | file | the epub file to validate | string |  | true | Should be a file with one of the following extensions: epub |
-|  | json-file | specifies that the validation output should be in JSON and in the specified file | string |  | false |  |
+|  | output-file | specifies that the validation output should be in the specified file | string |  | false |  |
 
 #### Usage
 

--- a/epub-lint/README.md
+++ b/epub-lint/README.md
@@ -64,6 +64,7 @@ Uses the provided epub and EPUBCheck output file to fix auto fixable auto fix is
     and starting the value with an underscore instead of a number if it currently is started by a number
   - Move attribute properties to their own meta elements that refine the element they were on to fix incorrect scheme declarations or other prefixes
   - Remove empty elements that should not be empty but are empty which is typically an identifier or description that has 0 content in it
+	- Update duplicate ids to no longer be duplicates
 - RSC-012: try to fix broken links by removing the id link in the href attribute
 
 

--- a/epub-lint/internal/epub-check/parse-validation-issues.go
+++ b/epub-lint/internal/epub-check/parse-validation-issues.go
@@ -1,0 +1,82 @@
+package epubcheck
+
+import (
+	"strconv"
+	"strings"
+)
+
+type ValidationError struct {
+	Code     string
+	FilePath string
+	Location *Position
+	Message  string
+}
+
+type Position struct {
+	Line   int
+	Column int
+}
+
+// ParseEPUBCheckOutput parses the contents of an EPUBCheck output from a string.
+func ParseEPUBCheckOutput(logContents string) ([]ValidationError, error) {
+	var errors []ValidationError
+	lines := strings.Split(logContents, "\n")
+
+	for _, line := range lines {
+		// Find the code (between first '(' and ')')
+		start := strings.Index(line, "(")
+		end := strings.Index(line, ")")
+		if start == -1 || end == -1 || end < start {
+			continue
+		}
+		code := line[start+1 : end]
+
+		// Find the .epub/ marker for file path
+		epubIdx := strings.Index(line, ".epub/")
+		if epubIdx == -1 {
+			continue
+		}
+		// Find the next '(' after .epub/ which marks the start of (line,column)
+		pathStart := epubIdx + len(".epub/")
+		pathEnd := strings.Index(line[pathStart:], "(")
+		if pathEnd == -1 {
+			continue
+		}
+		filePath := line[pathStart : pathStart+pathEnd]
+
+		// Get line and column (between '(' and ')' after file path)
+		locStart := pathStart + pathEnd + 1
+		locEnd := strings.Index(line[locStart:], ")")
+		if locEnd == -1 {
+			continue
+		}
+		locStr := line[locStart : locStart+locEnd]
+		locParts := strings.SplitN(locStr, ",", 2)
+		lineNum, colNum := -1, -1
+		if len(locParts) == 2 {
+			lineNum, _ = strconv.Atoi(strings.TrimSpace(locParts[0]))
+			colNum, _ = strconv.Atoi(strings.TrimSpace(locParts[1]))
+		}
+
+		// Message: after the final "):"
+		afterLoc := line[locStart+locEnd:]
+		colonIdx := strings.Index(afterLoc, ":")
+		if colonIdx == -1 {
+			continue
+		}
+		message := strings.TrimSpace(afterLoc[colonIdx+1:])
+
+		var pos *Position
+		if lineNum != -1 && colNum != -1 {
+			pos = &Position{Line: lineNum, Column: colNum}
+		}
+
+		errors = append(errors, ValidationError{
+			Code:     code,
+			FilePath: filePath,
+			Location: pos,
+			Message:  message,
+		})
+	}
+	return errors, nil
+}

--- a/epub-lint/internal/epub-check/parse-validation-issues_test.go
+++ b/epub-lint/internal/epub-check/parse-validation-issues_test.go
@@ -1,0 +1,76 @@
+//go:build unit
+
+package epubcheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type parseEPUBCheckTestCase struct {
+	name     string
+	input    string
+	expected []ValidationError
+}
+
+var parseEPUBCheckTestCases = []parseEPUBCheckTestCase{
+	{
+		name:     "no validation issues returns no values",
+		input:    "Validating using EPUB version 2.0.1 rules.\nCheck finished with errors\nMessages: 0 fatals / 0 errors / 0 warnings / 0 infos\nEPUBCheck completed",
+		expected: []ValidationError{},
+	},
+	{
+		name:  "single validation issue returns correct model",
+		input: `ERROR(RSC-005): /home/user/Documents/Book.epub/chapter1.html(5,10): Error while parsing file: element "img" missing required attribute "alt"`,
+		expected: []ValidationError{
+			{
+				Code:     "RSC-005",
+				FilePath: "chapter1.html",
+				Location: &Position{Line: 5, Column: 10},
+				Message:  `Error while parsing file: element "img" missing required attribute "alt"`,
+			},
+		},
+	},
+	{
+		name: "multiple validation issues returns multiple models",
+		input: `ERROR(RSC-005): /home/user/Documents/Book.epub/chapter1.html(5,10): Error while parsing file: element "img" missing required attribute "alt"
+ERROR(RSC-007): /home/user/Documents/Book.epub/chapter2.html(15,20): Referenced resource "chapter3.html" could not be found in the EPUB.`,
+		expected: []ValidationError{
+			{
+				Code:     "RSC-005",
+				FilePath: "chapter1.html",
+				Location: &Position{Line: 5, Column: 10},
+				Message:  `Error while parsing file: element "img" missing required attribute "alt"`,
+			},
+			{
+				Code:     "RSC-007",
+				FilePath: "chapter2.html",
+				Location: &Position{Line: 15, Column: 20},
+				Message:  `Referenced resource "chapter3.html" could not be found in the EPUB.`,
+			},
+		},
+	},
+	{
+		name:  "validation issue with -1,-1 results in nil Position",
+		input: `ERROR(RSC-999): /home/user/Documents/Book.epub/chapter4.html(-1,-1): Some general error with no position`,
+		expected: []ValidationError{
+			{
+				Code:     "RSC-999",
+				FilePath: "chapter4.html",
+				Location: nil,
+				Message:  "Some general error with no position",
+			},
+		},
+	},
+}
+
+func TestParseEPUBCheckOutput(t *testing.T) {
+	for _, tc := range parseEPUBCheckTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := ParseEPUBCheckOutput(tc.input)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/epub-lint/internal/epub-check/parse-validation-issues_test.go
+++ b/epub-lint/internal/epub-check/parse-validation-issues_test.go
@@ -18,7 +18,7 @@ var parseEPUBCheckTestCases = []parseEPUBCheckTestCase{
 	{
 		name:     "no validation issues returns no values",
 		input:    "Validating using EPUB version 2.0.1 rules.\nCheck finished with errors\nMessages: 0 fatals / 0 errors / 0 warnings / 0 infos\nEPUBCheck completed",
-		expected: []ValidationError{},
+		expected: nil,
 	},
 	{
 		name:  "single validation issue returns correct model",

--- a/epub-lint/internal/linter/update-duplicate-ids.go
+++ b/epub-lint/internal/linter/update-duplicate-ids.go
@@ -1,0 +1,44 @@
+package linter
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// UpdateDuplicateIds finds and renames duplicate IDs in file contents.
+// Returns the modified contents and the number of characters added.
+func UpdateDuplicateIds(contents, id string) (string, int) {
+	// Pattern: id="id" or id='id'
+	idPattern := fmt.Sprintf(`id=([\'"])%s[\'"]`, regexp.QuoteMeta(id))
+	re := regexp.MustCompile(idPattern)
+
+	matches := re.FindAllStringIndex(contents, -1)
+	if len(matches) <= 1 {
+		return contents, 0
+	}
+
+	var sb strings.Builder
+	var lastIdx int
+	addedChars := 0
+
+	for i, idx := range matches {
+		start, end := idx[0], idx[1]
+		sb.WriteString(contents[lastIdx:start])
+
+		// Write id= + quote + id
+		quote := contents[start+3]
+		sb.WriteString(contents[start : end-1]) // everything except closing quote
+
+		if i > 0 {
+			suffix := fmt.Sprintf("_%d", i+1)
+			sb.WriteString(suffix)
+			addedChars += len(suffix)
+		}
+		sb.WriteByte(quote)
+		lastIdx = end
+	}
+	sb.WriteString(contents[lastIdx:])
+
+	return sb.String(), addedChars
+}

--- a/epub-lint/internal/linter/update-duplicate-ids_test.go
+++ b/epub-lint/internal/linter/update-duplicate-ids_test.go
@@ -1,0 +1,85 @@
+//go:build unit
+
+package linter_test
+
+import (
+	"testing"
+
+	"github.com/pjkaufman/go-go-gadgets/epub-lint/internal/linter"
+	"github.com/stretchr/testify/assert"
+)
+
+type handleDuplicateIDTestCase struct {
+	name         string
+	contents     string
+	id           string
+	expected     string
+	expectedDiff int
+}
+
+var handleDuplicateIDTestCases = []handleDuplicateIDTestCase{
+	{
+		name: "id not present returns original and zero",
+		contents: `<html>
+  <body>
+    <div id="something"></div>
+  </body>
+</html>`,
+		id: "chapter1",
+		expected: `<html>
+  <body>
+    <div id="something"></div>
+  </body>
+</html>`,
+		expectedDiff: 0,
+	},
+	{
+		name: "two duplicate ids get _2 suffix on second occurrence and diff of 2",
+		contents: `<html>
+  <body>
+    <div id="chapter1"></div>
+    <span id="chapter1"></span>
+  </body>
+</html>`,
+		id: "chapter1",
+		expected: `<html>
+  <body>
+    <div id="chapter1"></div>
+    <span id="chapter1_2"></span>
+  </body>
+</html>`,
+		expectedDiff: 2,
+	},
+	{
+		name: "three duplicate ids get _2 and _3, total diff of 4 and no double _2",
+		contents: `<div id="chapter1"></div>
+<div id="chapter1"></div>
+<div id="chapter1"></div>`,
+		id: "chapter1",
+		expected: `<div id="chapter1"></div>
+<div id="chapter1_2"></div>
+<div id="chapter1_3"></div>`,
+		expectedDiff: 4,
+	},
+	{
+		name: "only exact matches updated even if the id to update is a subset of the id to remove duplicates for",
+		contents: `<div id="chapter1"></div>
+<div id="chapter1"></div>
+<div id="chapter1-long"></div>`,
+		id: "chapter1",
+		expected: `<div id="chapter1"></div>
+<div id="chapter1_2"></div>
+<div id="chapter1-long"></div>`,
+		expectedDiff: 2,
+	},
+}
+
+func TestHandleDuplicateID(t *testing.T) {
+	for _, tc := range handleDuplicateIDTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, diff := linter.UpdateDuplicateIds(tc.contents, tc.id)
+			assert.Equal(t, tc.expected, actual)
+			assert.Equal(t, tc.expectedDiff, diff)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #38 
Fixes #24 

Swapped to parse the normal CLI output for EPUBCheck due to the output being capped for the same issue to something like 18 entries. When there are hundreds or even a thousand errors of the same type this is not really a tenable way to fix things.

Also, added the logic necessary for handling duplicate ids by making all other ids except the first have `_X` where `X` is the count of the currently processed id instances plus 1.