### PR TITLE
Add Lint, Unit Test, and Deadcode CI Workflow

### DIFF
--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -1,0 +1,31 @@
+name: Change Validation
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  ci:
+    name: Change Validation
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      
+      - name: Get golangci-lint version
+        id: golangci_version
+        run: echo "version=$(grep GOLANG_CI_LINT_VERSION Makefile | cut -d= -f2)" >> $GITHUB_OUTPUT
+      
+      - name: Run tests
+        run: make test
+      
+      - name: Run linting
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: ${{ steps.golangci_version.outputs.version }}
+      
+      - name: Check for dead code
+        run: make deadcode

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
-          args: --out-format=sarif
       
       - name: Get golangci-lint version
         id: golangci_version
@@ -27,6 +26,7 @@ jobs:
         uses: golangci/golangci-lint-action@v4
         with:
           version: ${{ steps.golangci_version.outputs.version }}
+          args: --out-format=sarif
       
       - name: Check for dead code
         run: make deadcode

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -9,9 +9,8 @@ jobs:
     name: Change Validation
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       
@@ -23,10 +22,9 @@ jobs:
         run: make test
       
       - name: Run linting
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v9
         with:
           version: ${{ steps.golangci_version.outputs.version }}
-          args: --out-format=sarif
       
       - name: Check for dead code
         run: make deadcode

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -17,7 +17,7 @@ jobs:
       
       - name: Get golangci-lint version
         id: golangci_version
-        run: echo "version=$(grep GOLANG_CI_LINT_VERSION Makefile | cut -d= -f2)" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep -m 1 GOLANG_CI_LINT_VERSION Makefile | cut -d= -f2)" >> $GITHUB_OUTPUT
       
       - name: Run tests
         run: make test

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Change Validation

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+          args: --out-format=sarif
       
       - name: Get golangci-lint version
         id: golangci_version

--- a/.github/workflows/change.yml
+++ b/.github/workflows/change.yml
@@ -3,6 +3,8 @@ name: Change Validation
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@
 name: goreleaser
 
 on:
-  pull_request:
   push:
     tags:
       - "*"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_CMD = CGO_ENABLED=0 GOOS=linux go build $(BUILDFLAGS) $(LDFLAGS) $(GCFLAGS
 # Bash completion directory with fallback
 BASH_COMPLETION_DIR := $(or $(BASH_COMPLETION_USER_DIR),$(HOME)/.bash_completion.d)
 
-GOLANG_CI_LINT_VERSION=v2.16.0
+GOLANG_CI_LINT_VERSION=v2.11.4
 
 test:
 	go test ./... -tags "unit"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ BUILD_CMD = CGO_ENABLED=0 GOOS=linux go build $(BUILDFLAGS) $(LDFLAGS) $(GCFLAGS
 # Bash completion directory with fallback
 BASH_COMPLETION_DIR := $(or $(BASH_COMPLETION_USER_DIR),$(HOME)/.bash_completion.d)
 
-GOLANG_CI_LINT_VERSION=v2.9.0
+GOLANG_CI_LINT_VERSION=v2.16.0
 
 test:
 	go test ./... -tags "unit"

--- a/Makefile
+++ b/Makefile
@@ -111,4 +111,8 @@ ifeq (,$(shell which deadcode))
 endif
 
 	@echo "Checking for dead code..."
-	@deadcode -tags "unit,generate_doc,generate_golden" -test ./...
+	@output=$$(deadcode -tags "unit,generate_doc,generate_golden" -test ./...); \
+	if [ -n "$$output" ]; then \
+		echo "$$output"; \
+		exit 1; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -115,4 +115,6 @@ endif
 	if [ -n "$$output" ]; then \
 		echo "$$output"; \
 		exit 1; \
+	else \
+	  echo "No dead code found"; \
 	fi

--- a/epub-lint/internal/ui/common.go
+++ b/epub-lint/internal/ui/common.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"fmt"
 	"strings"
 	"unicode"
 
@@ -17,10 +16,6 @@ var (
 	editIcon     = string([]byte{0xE2, 0x9C, 0x8E})       // UTF-8 encoding for "✎"
 	warningIcon  = string([]byte{0xE2, 0x9A, 0xA0})       // UTF-8 encoding for "⚠"
 )
-
-func UnreachableCode() {
-	fmt.Println("Unreachable")
-}
 
 func fillLine(currentValue string, width int) string {
 	var amountToFill = width - lipgloss.Width(currentValue)

--- a/epub-lint/internal/ui/common.go
+++ b/epub-lint/internal/ui/common.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 
@@ -16,6 +17,10 @@ var (
 	editIcon     = string([]byte{0xE2, 0x9C, 0x8E})       // UTF-8 encoding for "✎"
 	warningIcon  = string([]byte{0xE2, 0x9A, 0xA0})       // UTF-8 encoding for "⚠"
 )
+
+func unreachableCode() {
+	fmt.Println("Unreachable")
+}
 
 func fillLine(currentValue string, width int) string {
 	var amountToFill = width - lipgloss.Width(currentValue)

--- a/epub-lint/internal/ui/common.go
+++ b/epub-lint/internal/ui/common.go
@@ -18,7 +18,7 @@ var (
 	warningIcon  = string([]byte{0xE2, 0x9A, 0xA0})       // UTF-8 encoding for "⚠"
 )
 
-func unreachableCode() {
+func UnreachableCode() {
 	fmt.Println("Unreachable")
 }
 

--- a/epub-lint/internal/ui/css-selection.go
+++ b/epub-lint/internal/ui/css-selection.go
@@ -16,7 +16,7 @@ func (m FixableIssuesModel) cssSelectionView() string {
 			cursor = ">"
 		}
 
-		s.WriteString(fmt.Sprintf("%s %d. %s\n", cursor, i+1, cssFile))
+		fmt.Fprintf(&s, "%s %d. %s\n", cursor, i+1, cssFile)
 	}
 
 	s.WriteString("\n")

--- a/magnum/cmd/validate-scrapers.go
+++ b/magnum/cmd/validate-scrapers.go
@@ -65,9 +65,9 @@ var ValidateScraperCmd = &cobra.Command{
 
 			scraperName = config.PublisherToDisplayString(series.Publisher)
 			if output.TotalVolumes == series.TotalVolumes && output.LatestVolume == series.LatestVolume {
-				validationResult.WriteString(fmt.Sprintf("- %s: working as expected\n", scraperName))
+				fmt.Fprintf(&validationResult, "- %s: working as expected\n", scraperName)
 			} else {
-				validationResult.WriteString(fmt.Sprintf("- %s: did not parse information correctly\n", scraperName))
+				fmt.Fprintf(&validationResult, "- %s: did not parse information correctly\n", scraperName)
 			}
 		}
 

--- a/magnum/cmd/validate-scrapers.go
+++ b/magnum/cmd/validate-scrapers.go
@@ -71,7 +71,7 @@ var ValidateScraperCmd = &cobra.Command{
 			}
 		}
 
-		validationResult.WriteString(fmt.Sprintf("- Wikipedia: not tested, but used for %s and %s", config.PublisherToDisplayString(config.HanashiMedia), config.PublisherToDisplayString(config.OnePeaceBooks)))
+		fmt.Fprintf(&validationResult, "- Wikipedia: not tested, but used for %s and %s", config.PublisherToDisplayString(config.HanashiMedia), config.PublisherToDisplayString(config.OnePeaceBooks))
 
 		logger.WriteInfo(validationResult.String())
 	},

--- a/magnum/internal/jnovel-club/get-volume-info_test.go
+++ b/magnum/internal/jnovel-club/get-volume-info_test.go
@@ -24,27 +24,27 @@ var (
 				ExpectedVolumes: []*sitehandler.VolumeInfo{
 					{
 						Name:        "Arifureta Zero: Volume 6",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2022, time.August, 4, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1659589200, 0)),
 					},
 					{
 						Name:        "Arifureta Zero: Volume 5",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2021, time.December, 1, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1638338400, 0)),
 					},
 					{
 						Name:        "Arifureta Zero: Volume 4",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2020, time.July, 6, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1594011600, 0)),
 					},
 					{
 						Name:        "Arifureta Zero: Volume 3",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2019, time.November, 16, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1573884000, 0)),
 					},
 					{
 						Name:        "Arifureta Zero: Volume 2",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2019, time.February, 4, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1549256400, 0)),
 					},
 					{
 						Name:        "Arifureta Zero: Volume 1",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2018, time.April, 11, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1523433600, 0)),
 					},
 				},
 				ExpectedCount: 6,
@@ -54,87 +54,87 @@ var (
 				ExpectedVolumes: []*sitehandler.VolumeInfo{
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Short Story Chronicles",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2026, time.June, 4, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1780549200, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 20",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2025, time.December, 29, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1766988000, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 19",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2025, time.March, 24, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1742792400, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 18",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2023, time.November, 29, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1701237600, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 17",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2022, time.November, 7, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1667800800, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 16",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2022, time.June, 7, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1654578000, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 15",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2022, time.January, 17, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1642399200, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 14",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2021, time.October, 25, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1635138000, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 13",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2021, time.March, 6, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1615010400, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 12",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2020, time.August, 22, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1598072400, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 11",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2020, time.April, 26, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1587877200, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 10",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2019, time.October, 20, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1571547600, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 9",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2019, time.July, 20, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1563598800, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 8",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2019, time.February, 15, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1550210400, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 7",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2018, time.September, 22, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1537610400, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 6",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2018, time.May, 31, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1527811200, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 5",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2018, time.February, 1, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1517464800, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 4",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2017, time.October, 18, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1508342400, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 3",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2017, time.August, 2, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1501686000, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 2",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2017, time.May, 13, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1494687600, 0)),
 					},
 					{
 						Name:        "How a Realist Hero Rebuilt the Kingdom: Volume 1",
-						ReleaseDate: sitehandler.TimePtr(time.Date(2017, time.February, 23, 0, 0, 0, 0, time.Local)),
+						ReleaseDate: sitehandler.TimePtr(time.Unix(1487862000, 0)),
 					},
 				},
 				ExpectedCount: 21,

--- a/song-converter/internal/converter/convert-md-to-html-song.go
+++ b/song-converter/internal/converter/convert-md-to-html-song.go
@@ -106,7 +106,7 @@ func buildDigitalMetadataDiv(metadata *SongMetadata, songType SongGenerationType
 
 	var (
 		addRowEntry = func(value, class, nonEmptyValue string) {
-			metadataHtml.WriteString(fmt.Sprintf("<div><div class=%q>", class))
+			fmt.Fprintf(&metadataHtml, "<div><div class=%q>", class)
 
 			if strings.Trim(value, "") != "" {
 				metadataHtml.WriteString(nonEmptyValue)


### PR DESCRIPTION
Fixes #93 

Adds the ability to run unit tests, deadcode checks, and unit tests from the CI.

Changes Made:
- Updated the golanglint-ci version
- Added a workflow for when changes are made UTs, linting, and dead code checks will be run
- Fixed a couple of linting errors
- Updated the `deadcode` make rule to exit with a non-zero status on deadcode finding dead code
- Stopped release checks from running on PRs
- Swapped to unix based time values in `j-novel.club` UTs as that is how the data is parsed in. This should allow it to work regardless of the timezone. It may be better to swap back to the prior approach, but find out what the seconds is in the other properties that get set and use UTC instead of local time