### PR TITLE
Epub Lint: Manually Fixable Issues - Gracefully Handle Paste Failing

### DIFF
--- a/epub-lint/internal/ui/fixable-issues.go
+++ b/epub-lint/internal/ui/fixable-issues.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 
@@ -13,7 +14,10 @@ import (
 	potentiallyfixableissue "github.com/pjkaufman/go-go-gadgets/epub-lint/internal/potentially-fixable-issue"
 )
 
-var ErrUserKilledProgram = errors.New("user killed program")
+var (
+	ErrUserKilledProgram    = errors.New("user killed program")
+	potentialFailedPasteMsg = "exit status 1"
+)
 
 const (
 	borderWidth      = 2
@@ -46,6 +50,8 @@ type FixableIssuesModel struct {
 type sectionBreakStageInfo struct {
 	input        textinput.Model
 	contextBreak *string
+	pasteFailed  bool
+	isPasting    bool // keep track of this so we know when to ignore an error that happens
 }
 
 type PotentiallyFixableStageInfo struct {
@@ -176,8 +182,16 @@ func (m FixableIssuesModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		cmds = append(cmds, tea.ClearScreen)
 	case error:
-		m.Err = msg
-		return m, tea.Quit
+		if m.logFile != nil {
+			fmt.Fprintf(m.logFile, "Unexpected error encountered %q. Stage is %d. Is pasting: %t. Is potential failed paste error: %t.\n", msg, m.currentStage, m.sectionBreakInfo.isPasting, potentialFailedPasteMsg == msg.Error())
+		}
+		if m.sectionBreakInfo.isPasting && potentialFailedPasteMsg == msg.Error() {
+			m.sectionBreakInfo.pasteFailed = true
+		} else {
+			m.Err = msg
+
+			return m, tea.Quit
+		}
 	}
 
 	switch m.currentStage {

--- a/epub-lint/internal/ui/section-break.go
+++ b/epub-lint/internal/ui/section-break.go
@@ -1,13 +1,19 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
 )
 
 func (m FixableIssuesModel) sectionBreakView() string {
-	return m.sectionBreakInfo.input.View()
+	var sectionBreakDisplay = m.sectionBreakInfo.input.View()
+	if !m.sectionBreakInfo.pasteFailed {
+		return sectionBreakDisplay
+	}
+
+	return warningStyle.Render(warningIcon+" The previous paste attempt failed. Please try again.") + "\n" + sectionBreakDisplay
 }
 
 func (m *FixableIssuesModel) handleSectionBreakMsgs(msg tea.Msg) tea.Cmd {
@@ -15,11 +21,23 @@ func (m *FixableIssuesModel) handleSectionBreakMsgs(msg tea.Msg) tea.Cmd {
 		cmd  tea.Cmd
 		cmds []tea.Cmd
 	)
+	oldValue := m.sectionBreakInfo.input.Value()
 	m.sectionBreakInfo.input, cmd = m.sectionBreakInfo.input.Update(msg)
+	newValue := m.sectionBreakInfo.input.Value()
 	cmds = append(cmds, cmd)
+
+	if oldValue != newValue { // only chide the warning once an actual change has been made to the text or another paste happens
+		m.sectionBreakInfo.pasteFailed = false
+	}
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if m.sectionBreakInfo.pasteFailed && m.logFile != nil {
+			fmt.Fprintln(m.logFile, "Next change after failed paste")
+		}
+
+		m.sectionBreakInfo.isPasting = false
+
 		switch msg.String() {
 		case "enter":
 			*m.sectionBreakInfo.contextBreak = strings.TrimSpace(m.sectionBreakInfo.input.Value())
@@ -35,6 +53,13 @@ func (m *FixableIssuesModel) handleSectionBreakMsgs(msg tea.Msg) tea.Cmd {
 
 				cmds = append(cmds, cmd)
 			}
+		case "ctrl+v":
+			if m.logFile != nil {
+				fmt.Fprintln(m.logFile, "Starting Paste")
+			}
+
+			m.sectionBreakInfo.pasteFailed = false
+			m.sectionBreakInfo.isPasting = true
 		}
 	}
 


### PR DESCRIPTION
Fixes #91 

There was an issue where when I would try to paste after closing a the app I copied from the program would crash. This is because an error was reported back from the paste. This would then get caught as a general error. This causes the TUI to crash with just the odd `exit status 1` error. Fixing this was a matter of keeping track of when I am pasting a value and then making sure that we check for failed paste events instead of just erroring out on generic errors.