### PR TITLE
Epub Lint: New Mobile Friendlier Layout

### DIFF
--- a/epub-lint/internal/ui/fixable-issues.go
+++ b/epub-lint/internal/ui/fixable-issues.go
@@ -20,11 +20,11 @@ var (
 )
 
 const (
-	borderWidth                 = 2
-	scrollbarPadding            = 3
-	minHeight                   = 21
-	minWidth                    = 41
-	minLargeHeaderTextThreshold = 73
+	borderWidth             = 2
+	scrollbarPadding        = 3
+	minHeight               = 21
+	minWidth                = 41
+	minLargeLayoutThreshold = 73
 )
 
 type stage int
@@ -44,7 +44,6 @@ type FixableIssuesModel struct {
 	body                         viewport.Model
 	title                        string
 	stages                       []string
-	shortStages                  []string
 	runAll, skipCss, ready       bool
 	height, width                int
 	logFile                      io.Writer
@@ -136,11 +135,6 @@ func NewFixableIssuesModel(runAll, skipCss, runSectionBreak bool, potentiallyFix
 			"Suggestions",
 			"Select CSS File",
 		},
-		shortStages: []string{
-			"Section",
-			"Suggestions",
-			"CSS",
-		},
 		title: "Manually Fixable Issues",
 	}
 }
@@ -184,10 +178,7 @@ func (m FixableIssuesModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.width = msg.Width
 
-		m.body.SetWidth(m.width)
-		m.body.SetHeight(max(0, m.height-(m.headerHeight()+m.footerHeight())))
-
-		m.setSuggestionDisplay(false)
+		m.recalculateElementSizes(false)
 
 		cmds = append(cmds, tea.ClearScreen)
 	case error:
@@ -245,6 +236,13 @@ func (m FixableIssuesModel) View() tea.View {
 	return view
 }
 
+func (m *FixableIssuesModel) recalculateElementSizes(resetSuggestionYOffset bool) {
+	m.body.SetWidth(m.width)
+	m.body.SetHeight(max(0, m.height-(m.headerHeight()+m.footerHeight())))
+
+	m.setSuggestionDisplay(resetSuggestionYOffset)
+}
+
 func (m FixableIssuesModel) headerView() string {
 	return headerBorderStyle.Render(fillLine(m.headerText(), m.width-headerBorderStyle.GetHorizontalBorderSize()))
 }
@@ -254,7 +252,7 @@ func (m FixableIssuesModel) headerText() string {
 }
 
 func (m FixableIssuesModel) getStageHeaders() string {
-	if m.width < minLargeHeaderTextThreshold {
+	if m.width < minLargeLayoutThreshold {
 		return activeStyle.Render(m.stages[min(int(m.currentStage), len(m.stages)-1)])
 	}
 
@@ -272,82 +270,6 @@ func (m FixableIssuesModel) getStageHeaders() string {
 	}
 
 	return strings.Join(stageHeaders, inactiveStyle.Render(" > "))
-}
-
-func (m FixableIssuesModel) footerView() string {
-	var (
-		s        strings.Builder
-		maxWidth = m.width - footerBorderStyle.GetHorizontalBorderSize()
-	)
-	s.WriteString(fillLine(controlsStyle.Render("Controls:"), maxWidth) + "\n")
-
-	var controls []string
-	switch m.currentStage {
-	case sectionBreak:
-		controls = []string{
-			"Enter: Accept",
-			"Esc: Quit",
-			"Ctrl+C: Exit without saving",
-		}
-	case suggestionsProcessing:
-		if m.PotentiallyFixableIssuesInfo.isEditing {
-			controls = []string{
-				"Ctrl+R: Reset",
-				"Ctrl+O: Original content",
-				"Ctrl+E: Cancel edit",
-				"Ctrl+S: Accept",
-				"Esc: Quit",
-				"Ctrl+C: Exit without saving",
-			}
-		} else if m.PotentiallyFixableIssuesInfo.currentSuggestionState != nil && m.PotentiallyFixableIssuesInfo.currentSuggestionState.isAccepted {
-			controls = []string{
-				"← / → : Previous/Next Suggestion",
-				"Ctrl+U / Ctrl+D: Previous/Next Potential Issue Type",
-				"Ctrl+PgUp / Ctrl+PgDn: Previous/Next File",
-				"C: Copy",
-				"Esc: Quit",
-				"Ctrl+C: Exit without saving",
-			}
-		} else {
-			controls = []string{
-				"← / → : Previous/Next Suggestion",
-				"Ctrl+U / Ctrl+D: Previous/Next Potential Issue Type",
-				"Ctrl+PgUp / Ctrl+PgDn: Previous/Next File",
-				"E: Edit",
-				"C: Copy",
-				"Enter: Accept",
-				"Esc: Quit",
-				"Ctrl+C: Exit without saving",
-			}
-		}
-	case stageCssSelection:
-		controls = []string{
-			"↑ / ↓ : Previous/Next Suggestion",
-			"Enter: Accept",
-			"Ctrl+C: Exit without saving",
-		}
-	}
-
-	var (
-		line strings.Builder
-	)
-	for _, help := range controls {
-		if line.Len() == 0 {
-			line.WriteString(help)
-			s.WriteString(help)
-		} else if line.Len()+len(help)+3 <= maxWidth {
-			s.WriteString(" • " + help)
-			line.WriteString(" • " + help)
-		} else {
-			s.WriteString("\n")
-			line.Reset()
-
-			line.WriteString(help)
-			s.WriteString(help)
-		}
-	}
-
-	return footerBorderStyle.Render(s.String())
 }
 
 func (m FixableIssuesModel) bodyView() string {
@@ -384,8 +306,4 @@ func (m FixableIssuesModel) headerHeight() int {
 
 func (m FixableIssuesModel) footerHeight() int {
 	return lipgloss.Height(m.footerView()) + footerBorderStyle.GetBorderTopSize()
-}
-
-func (m FixableIssuesModel) headerWidth() int {
-	return lipgloss.Width(m.headerText()) + headerBorderStyle.GetBorderBottomSize()
 }

--- a/epub-lint/internal/ui/fixable-issues.go
+++ b/epub-lint/internal/ui/fixable-issues.go
@@ -22,7 +22,7 @@ var (
 const (
 	borderWidth                 = 2
 	scrollbarPadding            = 3
-	minHeight                   = 41
+	minHeight                   = 21
 	minWidth                    = 41
 	minLargeHeaderTextThreshold = 71
 )

--- a/epub-lint/internal/ui/fixable-issues.go
+++ b/epub-lint/internal/ui/fixable-issues.go
@@ -24,7 +24,7 @@ const (
 	scrollbarPadding            = 3
 	minHeight                   = 21
 	minWidth                    = 41
-	minLargeHeaderTextThreshold = 71
+	minLargeHeaderTextThreshold = 73
 )
 
 type stage int
@@ -239,7 +239,7 @@ func (m FixableIssuesModel) View() tea.View {
 		)
 		m.body.SetContent(m.bodyView())
 
-		view.SetContent(lipgloss.JoinVertical(lipgloss.Center, header, m.body.View(), footer))
+		view.SetContent(lipgloss.JoinVertical(lipgloss.Left, header, m.body.View(), footer))
 	}
 
 	return view
@@ -250,23 +250,18 @@ func (m FixableIssuesModel) headerView() string {
 }
 
 func (m FixableIssuesModel) headerText() string {
-	if m.height < minLargeHeaderTextThreshold {
-		return lipgloss.JoinVertical(lipgloss.Left, titleStyle.Render(m.title), m.getStageHeaders())
-	}
-
 	return lipgloss.JoinHorizontal(lipgloss.Center, titleStyle.Render(m.title), " | ", m.getStageHeaders())
 }
 
 func (m FixableIssuesModel) getStageHeaders() string {
-	var stages = m.stages
-	if m.height < minLargeHeaderTextThreshold {
-		stages = m.shortStages
+	if m.width < minLargeHeaderTextThreshold {
+		return activeStyle.Render(m.stages[min(int(m.currentStage), len(m.stages)-1)])
 	}
 
-	var stageHeaders = make([]string, len(stages))
+	var stageHeaders = make([]string, len(m.stages))
 
 	var style lipgloss.Style
-	for i, header := range stages {
+	for i, header := range m.stages {
 		if i == int(m.currentStage) {
 			style = activeStyle
 		} else {

--- a/epub-lint/internal/ui/fixable-issues.go
+++ b/epub-lint/internal/ui/fixable-issues.go
@@ -22,7 +22,6 @@ var (
 const (
 	borderWidth      = 2
 	scrollbarPadding = 3
-	minWidth         = 75
 	minHeight        = 41
 )
 
@@ -220,6 +219,7 @@ func (m FixableIssuesModel) View() tea.View {
 	view := tea.NewView("")
 	view.AltScreen = true
 	if m.ready {
+		var minWidth = m.headerWidth()
 		if m.height < minHeight || m.width < minWidth {
 			view.SetContent(lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, fmt.Sprintf("Terminal size is too small:\nWidth = %d Height = %d\n\nMinimum Needed:\nWidth = %d Height = %d", m.width, m.height, minWidth, minHeight)))
 
@@ -239,7 +239,11 @@ func (m FixableIssuesModel) View() tea.View {
 }
 
 func (m FixableIssuesModel) headerView() string {
-	return headerBorderStyle.Render(fillLine(lipgloss.JoinHorizontal(lipgloss.Center, titleStyle.Render(m.title), " | ", m.getStageHeaders()), m.width-headerBorderStyle.GetHorizontalBorderSize()))
+	return headerBorderStyle.Render(fillLine(m.headerText(), m.width-headerBorderStyle.GetHorizontalBorderSize()))
+}
+
+func (m FixableIssuesModel) headerText() string {
+	return lipgloss.JoinHorizontal(lipgloss.Center, titleStyle.Render(m.title), " | ", m.getStageHeaders())
 }
 
 func (m FixableIssuesModel) getStageHeaders() string {
@@ -369,4 +373,8 @@ func (m FixableIssuesModel) headerHeight() int {
 
 func (m FixableIssuesModel) footerHeight() int {
 	return lipgloss.Height(m.footerView()) + footerBorderStyle.GetBorderTopSize()
+}
+
+func (m FixableIssuesModel) headerWidth() int {
+	return lipgloss.Width(m.headerText()) + headerBorderStyle.GetBorderBottomSize()
 }

--- a/epub-lint/internal/ui/fixable-issues.go
+++ b/epub-lint/internal/ui/fixable-issues.go
@@ -20,9 +20,11 @@ var (
 )
 
 const (
-	borderWidth      = 2
-	scrollbarPadding = 3
-	minHeight        = 41
+	borderWidth                 = 2
+	scrollbarPadding            = 3
+	minHeight                   = 41
+	minWidth                    = 41
+	minLargeHeaderTextThreshold = 71
 )
 
 type stage int
@@ -42,6 +44,7 @@ type FixableIssuesModel struct {
 	body                         viewport.Model
 	title                        string
 	stages                       []string
+	shortStages                  []string
 	runAll, skipCss, ready       bool
 	height, width                int
 	logFile                      io.Writer
@@ -133,6 +136,11 @@ func NewFixableIssuesModel(runAll, skipCss, runSectionBreak bool, potentiallyFix
 			"Suggestions",
 			"Select CSS File",
 		},
+		shortStages: []string{
+			"Section",
+			"Suggestions",
+			"CSS",
+		},
 		title: "Manually Fixable Issues",
 	}
 }
@@ -219,7 +227,6 @@ func (m FixableIssuesModel) View() tea.View {
 	view := tea.NewView("")
 	view.AltScreen = true
 	if m.ready {
-		var minWidth = m.headerWidth()
 		if m.height < minHeight || m.width < minWidth {
 			view.SetContent(lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, fmt.Sprintf("Terminal size is too small:\nWidth = %d Height = %d\n\nMinimum Needed:\nWidth = %d Height = %d", m.width, m.height, minWidth, minHeight)))
 
@@ -243,14 +250,23 @@ func (m FixableIssuesModel) headerView() string {
 }
 
 func (m FixableIssuesModel) headerText() string {
+	if m.height < minLargeHeaderTextThreshold {
+		return lipgloss.JoinVertical(lipgloss.Left, titleStyle.Render(m.title), m.getStageHeaders())
+	}
+
 	return lipgloss.JoinHorizontal(lipgloss.Center, titleStyle.Render(m.title), " | ", m.getStageHeaders())
 }
 
 func (m FixableIssuesModel) getStageHeaders() string {
-	var stageHeaders = make([]string, len(m.stages))
+	var stages = m.stages
+	if m.height < minLargeHeaderTextThreshold {
+		stages = m.shortStages
+	}
+
+	var stageHeaders = make([]string, len(stages))
 
 	var style lipgloss.Style
-	for i, header := range m.stages {
+	for i, header := range stages {
 		if i == int(m.currentStage) {
 			style = activeStyle
 		} else {

--- a/epub-lint/internal/ui/help.go
+++ b/epub-lint/internal/ui/help.go
@@ -3,143 +3,107 @@ package ui
 import (
 	"fmt"
 	"strings"
-
-	"charm.land/bubbles/v2/key"
 )
 
-type footerKeyMap struct {
-	PrevNextSuggestion key.Binding
-	PrevNextIssueType  key.Binding
-	PrevNextFile       key.Binding
-	Edit               key.Binding
-	Copy               key.Binding
-	Accept             key.Binding
-	Quit               key.Binding
-	ExitWithoutSaving  key.Binding
-	Reset              key.Binding
-	Original           key.Binding
-	CancelEdit         key.Binding
+type helpKeys struct {
+	prevNextSuggestion helpKey
+	prevNextIssueType  helpKey
+	prevNextFile       helpKey
+	edit               helpKey
+	copy               helpKey
+	accept             helpKey
+	quit               helpKey
+	exitWithoutSaving  helpKey
+	reset              helpKey
+	original           helpKey
+	cancelEdit         helpKey
 }
 
-type footerKeys struct {
-	Long  footerKeyMap
-	Short footerKeyMap
+type helpKey struct {
+	keys  string
+	short string
+	long  string
 }
 
 var (
-	masterKeyList = footerKeys{
-		Long: footerKeyMap{
-			PrevNextSuggestion: key.NewBinding(
-				key.WithKeys("left/right"),
-				key.WithHelp("←/→", "Previous/Next Suggestion"),
-			),
-			PrevNextIssueType: key.NewBinding(
-				key.WithKeys("ctrl+u/ctrl+d"),
-				key.WithHelp("^U/^D", "Previous/Next Issue Type"),
-			),
-			PrevNextFile: key.NewBinding(
-				key.WithKeys("pgup/pgdn"),
-				key.WithHelp("PgUp/PgDn", "Previous/Next File"),
-			),
-			Edit: key.NewBinding(
-				key.WithKeys("e"),
-				key.WithHelp("E", "Edit"),
-			),
-			Copy: key.NewBinding(
-				key.WithKeys("c"),
-				key.WithHelp("C", "Copy"),
-			),
-			Accept: key.NewBinding(
-				key.WithKeys("enter"),
-				key.WithHelp("Enter", "Accept"),
-			),
-			Quit: key.NewBinding(
-				key.WithKeys("esc"),
-				key.WithHelp("Esc", "Quit"),
-			),
-			ExitWithoutSaving: key.NewBinding(
-				key.WithKeys("ctrl+c"),
-				key.WithHelp("Ctrl+C", "Exit without saving"),
-			),
-			Reset: key.NewBinding(
-				key.WithKeys("ctrl+r"),
-				key.WithHelp("Ctrl+R", "Reset"),
-			),
-			Original: key.NewBinding(
-				key.WithKeys("ctrl+o"),
-				key.WithHelp("Ctrl+O", "Original content"),
-			),
-			CancelEdit: key.NewBinding(
-				key.WithKeys("ctrl+e"),
-				key.WithHelp("Ctrl+E", "Cancel edit"),
-			),
+	masterKeyList = helpKeys{
+		prevNextSuggestion: helpKey{
+			keys:  "←/→",
+			long:  "Previous/Next Suggestion",
+			short: "Suggestion",
 		},
-		Short: footerKeyMap{
-			PrevNextSuggestion: key.NewBinding(
-				key.WithKeys("left/right"),
-				key.WithHelp("←/→", "Suggestion"),
-			),
-			PrevNextIssueType: key.NewBinding(
-				key.WithKeys("ctrl+u/ctrl+d"),
-				key.WithHelp("^U/^D", "Issue Type"),
-			),
-			PrevNextFile: key.NewBinding(
-				key.WithKeys("pgup/pgdn"),
-				key.WithHelp("PgUp/PgDn", "File"),
-			),
-			Edit: key.NewBinding(
-				key.WithKeys("e"),
-				key.WithHelp("E", "Edit"),
-			),
-			Copy: key.NewBinding(
-				key.WithKeys("c"),
-				key.WithHelp("C", "Copy"),
-			),
-			Accept: key.NewBinding(
-				key.WithKeys("enter"),
-				key.WithHelp("Enter", "Accept"),
-			),
-			Quit: key.NewBinding(
-				key.WithKeys("esc"),
-				key.WithHelp("Esc", "Quit"),
-			),
-			ExitWithoutSaving: key.NewBinding(
-				key.WithKeys("ctrl+c"),
-				key.WithHelp("Ctrl+C", "Exit"),
-			),
-			Reset: key.NewBinding(
-				key.WithKeys("ctrl+r"),
-				key.WithHelp("Ctrl+R", "Reset"),
-			),
-			Original: key.NewBinding(
-				key.WithKeys("ctrl+o"),
-				key.WithHelp("Ctrl+O", "Original"),
-			),
-			CancelEdit: key.NewBinding(
-				key.WithKeys("ctrl+e"),
-				key.WithHelp("Ctrl+E", "Cancel"),
-			),
+		prevNextIssueType: helpKey{
+			keys:  "^U/^D",
+			long:  "Previous/Next Issue Type",
+			short: "Issue Type",
+		},
+		prevNextFile: helpKey{
+			keys:  "PgUp/PgDn",
+			long:  "Previous/Next File",
+			short: "File",
+		},
+		edit: helpKey{
+			keys:  "E",
+			long:  "Edit",
+			short: "Edit",
+		},
+		copy: helpKey{
+			keys:  "C",
+			long:  "Copy",
+			short: "Copy",
+		},
+		accept: helpKey{
+			keys:  "Enter",
+			long:  "Accept",
+			short: "Accept",
+		},
+		quit: helpKey{
+			keys:  "Esc",
+			long:  "Quit",
+			short: "Quit",
+		},
+		exitWithoutSaving: helpKey{
+			keys:  "Ctrl+C",
+			long:  "Exit without saving",
+			short: "Exit",
+		},
+		reset: helpKey{
+			keys:  "Ctrl+R",
+			long:  "Reset",
+			short: "Reset",
+		},
+		original: helpKey{
+			keys:  "Ctrl+O",
+			long:  "Original content",
+			short: "Original",
+		},
+		cancelEdit: helpKey{
+			keys:  "Ctrl+E",
+			long:  "Cancel edit",
+			short: "Cancel",
 		},
 	}
 )
 
 func (m FixableIssuesModel) footerView() string {
 	var (
-		keys     = masterKeyList.Long
 		maxWidth = m.width - footerBorderStyle.GetHorizontalBorderSize()
+		useShort = maxWidth < minLargeLayoutThreshold
 	)
-	if maxWidth < minLargeLayoutThreshold {
-		keys = masterKeyList.Short
-	}
 
 	var (
-		s    strings.Builder
-		line strings.Builder
-		help string
+		s          strings.Builder
+		line       strings.Builder
+		help, desc string
 	)
 	s.WriteString(fillLine(controlsStyle.Render("Controls:"), maxWidth) + "\n")
-	for _, key := range m.currentFooterBindings(keys) {
-		help = fmt.Sprintf("%s: %s", key.Help().Key, key.Help().Desc)
+	for _, key := range m.currentFooterBindings(masterKeyList) {
+		desc = key.long
+		if useShort {
+			desc = key.short
+		}
+
+		help = fmt.Sprintf("%s: %s", key.keys, desc)
 		if line.Len() == 0 {
 			line.WriteString(help)
 			s.WriteString(help)
@@ -160,56 +124,55 @@ func (m FixableIssuesModel) footerView() string {
 	return footerBorderStyle.Render(s.String())
 }
 
-func (m FixableIssuesModel) currentFooterBindings(keys footerKeyMap) []key.Binding {
+func (m FixableIssuesModel) currentFooterBindings(keys helpKeys) []helpKey {
 	switch m.currentStage {
 	case sectionBreak:
-		return []key.Binding{
-			keys.Accept,
-			keys.Quit,
-			keys.ExitWithoutSaving,
+		return []helpKey{
+			keys.accept,
+			keys.quit,
+			keys.exitWithoutSaving,
 		}
 
 	case suggestionsProcessing:
 		if m.PotentiallyFixableIssuesInfo.isEditing {
-			return []key.Binding{
-				keys.Reset,
-				keys.Original,
-				keys.CancelEdit,
-				keys.Accept,
-				keys.Quit,
-				keys.ExitWithoutSaving,
+			return []helpKey{
+				keys.reset,
+				keys.original,
+				keys.cancelEdit,
+				keys.accept,
+				keys.quit,
+				keys.exitWithoutSaving,
 			}
 		}
 
 		if m.PotentiallyFixableIssuesInfo.currentSuggestionState != nil &&
 			m.PotentiallyFixableIssuesInfo.currentSuggestionState.isAccepted {
-
-			return []key.Binding{
-				keys.PrevNextSuggestion,
-				keys.PrevNextIssueType,
-				keys.PrevNextFile,
-				keys.Copy,
-				keys.Quit,
-				keys.ExitWithoutSaving,
+			return []helpKey{
+				keys.prevNextSuggestion,
+				keys.prevNextIssueType,
+				keys.prevNextFile,
+				keys.copy,
+				keys.quit,
+				keys.exitWithoutSaving,
 			}
 		}
 
-		return []key.Binding{
-			keys.PrevNextSuggestion,
-			keys.PrevNextIssueType,
-			keys.PrevNextFile,
-			keys.Edit,
-			keys.Copy,
-			keys.Accept,
-			keys.Quit,
-			keys.ExitWithoutSaving,
+		return []helpKey{
+			keys.prevNextSuggestion,
+			keys.prevNextIssueType,
+			keys.prevNextFile,
+			keys.edit,
+			keys.copy,
+			keys.accept,
+			keys.quit,
+			keys.exitWithoutSaving,
 		}
 
 	case stageCssSelection:
-		return []key.Binding{
-			keys.PrevNextSuggestion,
-			keys.Accept,
-			keys.ExitWithoutSaving,
+		return []helpKey{
+			keys.prevNextSuggestion,
+			keys.accept,
+			keys.exitWithoutSaving,
 		}
 	}
 

--- a/epub-lint/internal/ui/help.go
+++ b/epub-lint/internal/ui/help.go
@@ -84,8 +84,8 @@ var (
 				key.WithHelp("^U/^D", "Issue Type"),
 			),
 			PrevNextFile: key.NewBinding(
-				key.WithKeys("ctrl+pgup/ctrl+pgdn"),
-				key.WithHelp("^PgUp/^PgDn", "File"),
+				key.WithKeys("pgup/pgdn"),
+				key.WithHelp("PgUp/PgDn", "File"),
 			),
 			Edit: key.NewBinding(
 				key.WithKeys("e"),

--- a/epub-lint/internal/ui/help.go
+++ b/epub-lint/internal/ui/help.go
@@ -1,0 +1,217 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+)
+
+type footerKeyMap struct {
+	PrevNextSuggestion key.Binding
+	PrevNextIssueType  key.Binding
+	PrevNextFile       key.Binding
+	Edit               key.Binding
+	Copy               key.Binding
+	Accept             key.Binding
+	Quit               key.Binding
+	ExitWithoutSaving  key.Binding
+	Reset              key.Binding
+	Original           key.Binding
+	CancelEdit         key.Binding
+}
+
+type footerKeys struct {
+	Long  footerKeyMap
+	Short footerKeyMap
+}
+
+var (
+	masterKeyList = footerKeys{
+		Long: footerKeyMap{
+			PrevNextSuggestion: key.NewBinding(
+				key.WithKeys("left/right"),
+				key.WithHelp("←/→", "Previous/Next Suggestion"),
+			),
+			PrevNextIssueType: key.NewBinding(
+				key.WithKeys("ctrl+u/ctrl+d"),
+				key.WithHelp("^U/^D", "Previous/Next Issue Type"),
+			),
+			PrevNextFile: key.NewBinding(
+				key.WithKeys("pgup/pgdn"),
+				key.WithHelp("PgUp/PgDn", "Previous/Next File"),
+			),
+			Edit: key.NewBinding(
+				key.WithKeys("e"),
+				key.WithHelp("E", "Edit"),
+			),
+			Copy: key.NewBinding(
+				key.WithKeys("c"),
+				key.WithHelp("C", "Copy"),
+			),
+			Accept: key.NewBinding(
+				key.WithKeys("enter"),
+				key.WithHelp("Enter", "Accept"),
+			),
+			Quit: key.NewBinding(
+				key.WithKeys("esc"),
+				key.WithHelp("Esc", "Quit"),
+			),
+			ExitWithoutSaving: key.NewBinding(
+				key.WithKeys("ctrl+c"),
+				key.WithHelp("Ctrl+C", "Exit without saving"),
+			),
+			Reset: key.NewBinding(
+				key.WithKeys("ctrl+r"),
+				key.WithHelp("Ctrl+R", "Reset"),
+			),
+			Original: key.NewBinding(
+				key.WithKeys("ctrl+o"),
+				key.WithHelp("Ctrl+O", "Original content"),
+			),
+			CancelEdit: key.NewBinding(
+				key.WithKeys("ctrl+e"),
+				key.WithHelp("Ctrl+E", "Cancel edit"),
+			),
+		},
+		Short: footerKeyMap{
+			PrevNextSuggestion: key.NewBinding(
+				key.WithKeys("left/right"),
+				key.WithHelp("←/→", "Suggestion"),
+			),
+			PrevNextIssueType: key.NewBinding(
+				key.WithKeys("ctrl+u/ctrl+d"),
+				key.WithHelp("^U/^D", "Issue Type"),
+			),
+			PrevNextFile: key.NewBinding(
+				key.WithKeys("ctrl+pgup/ctrl+pgdn"),
+				key.WithHelp("^PgUp/^PgDn", "File"),
+			),
+			Edit: key.NewBinding(
+				key.WithKeys("e"),
+				key.WithHelp("E", "Edit"),
+			),
+			Copy: key.NewBinding(
+				key.WithKeys("c"),
+				key.WithHelp("C", "Copy"),
+			),
+			Accept: key.NewBinding(
+				key.WithKeys("enter"),
+				key.WithHelp("Enter", "Accept"),
+			),
+			Quit: key.NewBinding(
+				key.WithKeys("esc"),
+				key.WithHelp("Esc", "Quit"),
+			),
+			ExitWithoutSaving: key.NewBinding(
+				key.WithKeys("ctrl+c"),
+				key.WithHelp("Ctrl+C", "Exit"),
+			),
+			Reset: key.NewBinding(
+				key.WithKeys("ctrl+r"),
+				key.WithHelp("Ctrl+R", "Reset"),
+			),
+			Original: key.NewBinding(
+				key.WithKeys("ctrl+o"),
+				key.WithHelp("Ctrl+O", "Original"),
+			),
+			CancelEdit: key.NewBinding(
+				key.WithKeys("ctrl+e"),
+				key.WithHelp("Ctrl+E", "Cancel"),
+			),
+		},
+	}
+)
+
+func (m FixableIssuesModel) footerView() string {
+	var (
+		keys     = masterKeyList.Long
+		maxWidth = m.width - footerBorderStyle.GetHorizontalBorderSize()
+	)
+	if maxWidth < minLargeLayoutThreshold {
+		keys = masterKeyList.Short
+	}
+
+	var (
+		s    strings.Builder
+		line strings.Builder
+		help string
+	)
+	s.WriteString(fillLine(controlsStyle.Render("Controls:"), maxWidth) + "\n")
+	for _, key := range m.currentFooterBindings(keys) {
+		help = fmt.Sprintf("%s: %s", key.Help().Key, key.Help().Desc)
+		if line.Len() == 0 {
+			line.WriteString(help)
+			s.WriteString(help)
+		} else if line.Len()+len(help)+3 <= maxWidth {
+			s.WriteString(controlsStyle.Render(" • "))
+			line.WriteString(controlsStyle.Render(" • "))
+			s.WriteString(help)
+			line.WriteString(help)
+		} else {
+			s.WriteString("\n")
+			line.Reset()
+
+			line.WriteString(help)
+			s.WriteString(help)
+		}
+	}
+
+	return footerBorderStyle.Render(s.String())
+}
+
+func (m FixableIssuesModel) currentFooterBindings(keys footerKeyMap) []key.Binding {
+	switch m.currentStage {
+	case sectionBreak:
+		return []key.Binding{
+			keys.Accept,
+			keys.Quit,
+			keys.ExitWithoutSaving,
+		}
+
+	case suggestionsProcessing:
+		if m.PotentiallyFixableIssuesInfo.isEditing {
+			return []key.Binding{
+				keys.Reset,
+				keys.Original,
+				keys.CancelEdit,
+				keys.Accept,
+				keys.Quit,
+				keys.ExitWithoutSaving,
+			}
+		}
+
+		if m.PotentiallyFixableIssuesInfo.currentSuggestionState != nil &&
+			m.PotentiallyFixableIssuesInfo.currentSuggestionState.isAccepted {
+
+			return []key.Binding{
+				keys.PrevNextSuggestion,
+				keys.PrevNextIssueType,
+				keys.PrevNextFile,
+				keys.Copy,
+				keys.Quit,
+				keys.ExitWithoutSaving,
+			}
+		}
+
+		return []key.Binding{
+			keys.PrevNextSuggestion,
+			keys.PrevNextIssueType,
+			keys.PrevNextFile,
+			keys.Edit,
+			keys.Copy,
+			keys.Accept,
+			keys.Quit,
+			keys.ExitWithoutSaving,
+		}
+
+	case stageCssSelection:
+		return []key.Binding{
+			keys.PrevNextSuggestion,
+			keys.Accept,
+			keys.ExitWithoutSaving,
+		}
+	}
+
+	return nil
+}

--- a/epub-lint/internal/ui/styles.go
+++ b/epub-lint/internal/ui/styles.go
@@ -15,4 +15,5 @@ var (
 	leftStatusBorderStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder(), true).BorderForeground(lipgloss.Color("#74c7ec"))
 	suggestionBorderStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder(), true)
 	displayStyle          = lipgloss.NewStyle()
+	hrStyle               = lipgloss.NewStyle().Foreground(lipgloss.BrightWhite)
 )

--- a/epub-lint/internal/ui/suggestions.go
+++ b/epub-lint/internal/ui/suggestions.go
@@ -271,7 +271,7 @@ func (m *FixableIssuesModel) handleSuggestionMsgs(msg tea.Msg) tea.Cmd {
 				cmds = append(cmds, cmd)
 			case "ctrl+u":
 				m.moveToPreviousIssue()
-			case "ctrl+pgdown":
+			case "pgdown":
 				cmd, err := m.moveToNextFile()
 				if err != nil {
 					m.Err = err
@@ -280,7 +280,7 @@ func (m *FixableIssuesModel) handleSuggestionMsgs(msg tea.Msg) tea.Cmd {
 				}
 
 				cmds = append(cmds, cmd)
-			case "ctrl+pgup":
+			case "pgup":
 				m.moveToPreviousFile()
 			}
 		}

--- a/epub-lint/internal/ui/suggestions.go
+++ b/epub-lint/internal/ui/suggestions.go
@@ -437,7 +437,7 @@ func (m *FixableIssuesModel) moveToNextFile() (tea.Cmd, error) {
 		m.PotentiallyFixableIssuesInfo.currentFile = m.PotentiallyFixableIssuesInfo.FileSuggestionData[m.PotentiallyFixableIssuesInfo.currentFileIndex].Name
 		m.PotentiallyFixableIssuesInfo.currentSuggestionName = m.PotentiallyFixableIssuesInfo.suggestions[m.PotentiallyFixableIssuesInfo.potentialFixableIssueIndex].Name
 	} else {
-		m.PotentiallyFixableIssuesInfo.potentialFixableIssueIndex = len(m.PotentiallyFixableIssuesInfo.suggestions)
+		m.PotentiallyFixableIssuesInfo.potentialFixableIssueIndex = len(m.PotentiallyFixableIssuesInfo.suggestions) - 1
 		m.PotentiallyFixableIssuesInfo.currentSuggestionIndex = len(m.PotentiallyFixableIssuesInfo.FileSuggestionData[m.PotentiallyFixableIssuesInfo.currentFileIndex].Suggestions[m.PotentiallyFixableIssuesInfo.potentialFixableIssueIndex])
 	}
 

--- a/epub-lint/internal/ui/suggestions.go
+++ b/epub-lint/internal/ui/suggestions.go
@@ -16,13 +16,13 @@ func (m *FixableIssuesModel) suggestionsView() string {
 	return m.suggestionView()
 }
 
-func (m FixableIssuesModel) getSuggestionWidth(statusWidth int) int {
+func (m FixableIssuesModel) getSuggestionWidth() int {
 	return m.body.Width() - (suggestionBorderStyle.GetBorderLeftSize() + suggestionBorderStyle.GetBorderRightSize())
 }
 
 func (m *FixableIssuesModel) suggestionHeaderView() string {
 	var (
-		maxTextWidth           = m.getSuggestionWidth(0)
+		maxTextWidth           = m.getSuggestionWidth()
 		fileName               = m.PotentiallyFixableIssuesInfo.currentFile
 		fileStatus             string
 		fileNumberInfo         = fmt.Sprintf("(%d/%d)", m.PotentiallyFixableIssuesInfo.currentFileIndex+1, len(m.PotentiallyFixableIssuesInfo.FileSuggestionData))
@@ -556,7 +556,7 @@ func (m *FixableIssuesModel) setSuggestionDisplay(resetYOffset bool) {
 
 	var (
 		height         = max(m.body.Height()-leftStatusBorderStyle.GetVerticalBorderSize()-strings.Count(m.suggestionHeaderView(), "\n"), 0)
-		remainingWidth = m.getSuggestionWidth(0)
+		remainingWidth = m.getSuggestionWidth()
 	)
 
 	if m.logFile != nil {

--- a/epub-lint/internal/ui/suggestions.go
+++ b/epub-lint/internal/ui/suggestions.go
@@ -12,77 +12,12 @@ import (
 	"github.com/muesli/reflow/wordwrap"
 )
 
-const maxLeftStatusWidth = 40
-
 func (m *FixableIssuesModel) suggestionsView() string {
-	// return lipgloss.JoinHorizontal(lipgloss.Left, m.leftStatusView(), m.suggestionView())
 	return m.suggestionView()
 }
 
 func (m FixableIssuesModel) getSuggestionWidth(statusWidth int) int {
 	return m.body.Width() - (suggestionBorderStyle.GetBorderLeftSize() + suggestionBorderStyle.GetBorderRightSize())
-	// return m.body.Width() - (statusWidth + leftStatusBorderStyle.GetBorderLeftSize() + suggestionBorderStyle.GetBorderRightSize())
-}
-
-// func (m FixableIssuesModel) getLeftStatusWidth() int {
-// 	return min(lipgloss.Width(m.leftStatusView()), maxLeftStatusWidth)
-// }
-
-func (m *FixableIssuesModel) leftStatusView() string {
-	var (
-		maxTextWidth           = maxLeftStatusWidth - leftStatusBorderStyle.GetHorizontalBorderSize()
-		fileName               = m.PotentiallyFixableIssuesInfo.currentFile
-		fileStatus             string
-		fileNumberInfo         = fmt.Sprintf("(%d/%d)", m.PotentiallyFixableIssuesInfo.currentFileIndex+1, len(m.PotentiallyFixableIssuesInfo.FileSuggestionData))
-		remainingFileNameWidth = maxTextWidth - (lipgloss.Width(documentIcon) + 2 + lipgloss.Width(fileNumberInfo) + lipgloss.Width(m.PotentiallyFixableIssuesInfo.currentFile))
-	)
-
-	// truncate file name
-	if remainingFileNameWidth < 0 {
-		fileName = "..." + fileName[remainingFileNameWidth*-1+3:]
-		fileStatus = documentIcon + " " + fileNameStyle.Render(fileName+" "+fileNumberInfo)
-	} else {
-		fileStatus = fillLine(documentIcon+" "+fileNameStyle.Render(fileName+" "+fileNumberInfo), maxTextWidth)
-	}
-
-	var suggestionStatus = wordwrap.String(sectionIcon+" "+m.PotentiallyFixableIssuesInfo.currentSuggestionName+fmt.Sprintf(" (%d/%d)", m.PotentiallyFixableIssuesInfo.potentialFixableIssueIndex+1, len(m.PotentiallyFixableIssuesInfo.suggestions)), maxTextWidth)
-	var lines = strings.Split(suggestionStatus, "\n")
-
-	var afterIcon = strings.Index(lines[0], " ") + 1
-	lines[0] = lines[0][:afterIcon] + suggestionNameStyle.Render(lines[0][afterIcon:])
-	for i := 1; i < len(lines); i++ {
-		lines[i] = suggestionNameStyle.Render(lines[i])
-	}
-
-	suggestionStatus = strings.Join(lines, "\n")
-
-	var warningStatus = ""
-	if m.PotentiallyFixableIssuesInfo.currentSuggestionState != nil && m.PotentiallyFixableIssuesInfo.currentSuggestionState.originallyHadHalfwidthCircleKatakana {
-		warningStatus = wordwrap.String(warningIcon+" "+warningStyle.Render(` At least one instance of "°" in the displayed text may be the Japanese handakuten.`), maxTextWidth)
-		lines = strings.Split(warningStatus, "\n")
-
-		var afterIcon = strings.Index(lines[0], " ") + 1
-		lines[0] = lines[0][:afterIcon] + warningStyle.Render(lines[0][afterIcon:])
-		for i := 1; i < len(lines); i++ {
-			lines[i] = warningStyle.Render(lines[i])
-		}
-
-		warningStatus = "\n" + strings.Join(lines, "\n")
-	}
-
-	var (
-		statusView      = fileStatus + "\n" + suggestionStatus + warningStatus
-		remainingHeight int
-		statusPadding   string
-	)
-
-	remainingHeight = m.body.Height() - (lipgloss.Height(statusView) + leftStatusBorderStyle.GetVerticalBorderSize())
-
-	if remainingHeight > 0 {
-		statusPadding = strings.Repeat("\n", remainingHeight)
-	}
-
-	return leftStatusBorderStyle.Render(statusView + statusPadding)
 }
 
 func (m *FixableIssuesModel) suggestionHeaderView() string {
@@ -213,7 +148,7 @@ func (m *FixableIssuesModel) handleSuggestionMsgs(msg tea.Msg) tea.Cmd {
 					return tea.Quit
 				}
 
-				m.setSuggestionDisplay(true)
+				m.recalculateElementSizes(true)
 
 				return tea.Batch(cmds...)
 			case "ctrl+e":
@@ -227,6 +162,8 @@ func (m *FixableIssuesModel) handleSuggestionMsgs(msg tea.Msg) tea.Cmd {
 
 					return tea.Quit
 				}
+
+				m.recalculateElementSizes(false)
 			case "ctrl+r":
 				var originalSuggestion = m.PotentiallyFixableIssuesInfo.currentSuggestionState.originalSuggestion
 				originalSuggestion, m.PotentiallyFixableIssuesInfo.currentSuggestionState.originallyHadHalfwidthCircleKatakana = replaceBrokenDisplayCharacters(originalSuggestion)
@@ -275,15 +212,6 @@ func (m *FixableIssuesModel) handleSuggestionMsgs(msg tea.Msg) tea.Cmd {
 			case "left":
 				m.moveToPreviousSuggestion()
 			case "c":
-				// Copy original value to the clipboard
-				// original, err := repairUnicode(m.currentFileState.original)
-				// if err != nil {
-				// 	m.Err = err
-
-				// 	return m, tea.Quit
-				// }
-
-				// err = clipboard.WriteAll(original)
 				// TODO: make sure values are utf-8 compliant
 				err := clipboard.WriteAll(m.PotentiallyFixableIssuesInfo.currentSuggestionState.original)
 				if err != nil {
@@ -329,6 +257,8 @@ func (m *FixableIssuesModel) handleSuggestionMsgs(msg tea.Msg) tea.Cmd {
 
 					cmd = m.PotentiallyFixableIssuesInfo.suggestionEdit.Focus()
 					cmds = append(cmds, cmd)
+
+					m.recalculateElementSizes(false)
 				}
 			case "ctrl+d":
 				cmd, err := m.moveToNextIssue()

--- a/epub-lint/internal/ui/suggestions.go
+++ b/epub-lint/internal/ui/suggestions.go
@@ -15,16 +15,18 @@ import (
 const maxLeftStatusWidth = 40
 
 func (m *FixableIssuesModel) suggestionsView() string {
-	return lipgloss.JoinHorizontal(lipgloss.Left, m.leftStatusView(), m.suggestionView())
+	// return lipgloss.JoinHorizontal(lipgloss.Left, m.leftStatusView(), m.suggestionView())
+	return m.suggestionView()
 }
 
 func (m FixableIssuesModel) getSuggestionWidth(statusWidth int) int {
-	return m.body.Width() - (statusWidth + leftStatusBorderStyle.GetBorderLeftSize() + suggestionBorderStyle.GetBorderRightSize())
+	return m.body.Width() - (suggestionBorderStyle.GetBorderLeftSize() + suggestionBorderStyle.GetBorderRightSize())
+	// return m.body.Width() - (statusWidth + leftStatusBorderStyle.GetBorderLeftSize() + suggestionBorderStyle.GetBorderRightSize())
 }
 
-func (m FixableIssuesModel) getLeftStatusWidth() int {
-	return min(lipgloss.Width(m.leftStatusView()), maxLeftStatusWidth)
-}
+// func (m FixableIssuesModel) getLeftStatusWidth() int {
+// 	return min(lipgloss.Width(m.leftStatusView()), maxLeftStatusWidth)
+// }
 
 func (m *FixableIssuesModel) leftStatusView() string {
 	var (
@@ -83,38 +85,92 @@ func (m *FixableIssuesModel) leftStatusView() string {
 	return leftStatusBorderStyle.Render(statusView + statusPadding)
 }
 
-func (m *FixableIssuesModel) suggestionView() string {
-	var s strings.Builder
+func (m *FixableIssuesModel) suggestionHeaderView() string {
+	var (
+		maxTextWidth           = m.getSuggestionWidth(0)
+		fileName               = m.PotentiallyFixableIssuesInfo.currentFile
+		fileStatus             string
+		fileNumberInfo         = fmt.Sprintf("(%d/%d)", m.PotentiallyFixableIssuesInfo.currentFileIndex+1, len(m.PotentiallyFixableIssuesInfo.FileSuggestionData))
+		remainingFileNameWidth = maxTextWidth - (lipgloss.Width(documentIcon) + 2 + lipgloss.Width(fileNumberInfo) + lipgloss.Width(m.PotentiallyFixableIssuesInfo.currentFile))
+	)
 
-	if m.PotentiallyFixableIssuesInfo.currentSuggestionState == nil {
-		s.WriteString("\nNo current file is selected. Something may have gone wrong...\n\n")
+	// truncate file name
+	if remainingFileNameWidth < 0 {
+		fileName = "..." + fileName[remainingFileNameWidth*-1+3:]
+		fileStatus = documentIcon + " " + fileNameStyle.Render(fileName+" "+fileNumberInfo)
 	} else {
-		modeIcon := viewIcon
-		modeName := "View"
-		if m.PotentiallyFixableIssuesInfo.isEditing {
-			modeIcon = editIcon
-			modeName = "Edit"
-		}
-
-		if m.PotentiallyFixableIssuesInfo.isEditing {
-			var customBorderStyle = m.createCustomBorder(modeIcon, modeName, 0)
-
-			s.WriteString(customBorderStyle.Render(m.PotentiallyFixableIssuesInfo.suggestionEdit.View()) + "\n\n")
-		} else if m.PotentiallyFixableIssuesInfo.suggestionDisplay.TotalLineCount() > m.PotentiallyFixableIssuesInfo.suggestionDisplay.VisibleLineCount() {
-			var customBorderStyle = m.createCustomBorder(modeIcon, modeName, scrollbarPadding)
-
-			s.WriteString(customBorderStyle.Render(lipgloss.JoinHorizontal(lipgloss.Top,
-				m.PotentiallyFixableIssuesInfo.suggestionDisplay.View(),
-				m.PotentiallyFixableIssuesInfo.scrollbar.View().Content,
-			)))
-		} else {
-			var customBorderStyle = m.createCustomBorder(modeIcon, modeName, 0)
-
-			s.WriteString(customBorderStyle.Render(m.PotentiallyFixableIssuesInfo.suggestionDisplay.View()))
-		}
+		fileStatus = fillLine(documentIcon+" "+fileNameStyle.Render(fileName+" "+fileNumberInfo), maxTextWidth)
 	}
 
-	return s.String()
+	var suggestionStatus = wordwrap.String(sectionIcon+" "+m.PotentiallyFixableIssuesInfo.currentSuggestionName+fmt.Sprintf(" (%d/%d)", m.PotentiallyFixableIssuesInfo.potentialFixableIssueIndex+1, len(m.PotentiallyFixableIssuesInfo.suggestions)), maxTextWidth)
+	var lines = strings.Split(suggestionStatus, "\n")
+
+	var afterIcon = strings.Index(lines[0], " ") + 1
+	lines[0] = lines[0][:afterIcon] + suggestionNameStyle.Render(lines[0][afterIcon:])
+	for i := 1; i < len(lines); i++ {
+		lines[i] = suggestionNameStyle.Render(lines[i])
+	}
+
+	suggestionStatus = strings.Join(lines, "\n")
+
+	var warningStatus = ""
+	if m.PotentiallyFixableIssuesInfo.currentSuggestionState != nil && m.PotentiallyFixableIssuesInfo.currentSuggestionState.originallyHadHalfwidthCircleKatakana {
+		warningStatus = wordwrap.String(warningIcon+" "+warningStyle.Render(` At least one instance of "°" in the displayed text may be the Japanese handakuten.`), maxTextWidth)
+		lines = strings.Split(warningStatus, "\n")
+
+		var afterIcon = strings.Index(lines[0], " ") + 1
+		lines[0] = lines[0][:afterIcon] + warningStyle.Render(lines[0][afterIcon:])
+		for i := 1; i < len(lines); i++ {
+			lines[i] = warningStyle.Render(lines[i])
+		}
+
+		warningStatus = "\n" + strings.Join(lines, "\n")
+	}
+
+	return fmt.Sprintf("%s\n%s%s\n%s\n", fileStatus, suggestionStatus, warningStatus, hrStyle.Render(strings.Repeat("─", maxTextWidth)))
+}
+
+func (m *FixableIssuesModel) suggestionView() string {
+	if m.PotentiallyFixableIssuesInfo.currentSuggestionState == nil {
+		return "\nNo current file is selected. Something may have gone wrong...\n\n"
+	}
+
+	var (
+		modeIcon = viewIcon
+		modeName = "View"
+		s        strings.Builder
+	)
+	if m.PotentiallyFixableIssuesInfo.isEditing {
+		modeIcon = editIcon
+		modeName = "Edit"
+	}
+
+	var (
+		customBorderPadding = 0
+		customBorderStyle   lipgloss.Style
+		isUsingScrollbar    bool
+	)
+	if !m.PotentiallyFixableIssuesInfo.isEditing && m.PotentiallyFixableIssuesInfo.suggestionDisplay.TotalLineCount() > m.PotentiallyFixableIssuesInfo.suggestionDisplay.VisibleLineCount() {
+		isUsingScrollbar = true
+		customBorderPadding = scrollbarPadding
+	}
+
+	s.WriteString(m.suggestionHeaderView())
+
+	customBorderStyle = m.createCustomBorder(modeIcon, modeName, customBorderPadding)
+
+	if m.PotentiallyFixableIssuesInfo.isEditing {
+		s.WriteString(m.PotentiallyFixableIssuesInfo.suggestionEdit.View())
+	} else if isUsingScrollbar {
+		s.WriteString(lipgloss.JoinHorizontal(lipgloss.Top,
+			m.PotentiallyFixableIssuesInfo.suggestionDisplay.View(),
+			m.PotentiallyFixableIssuesInfo.scrollbar.View().Content,
+		))
+	} else {
+		s.WriteString(m.PotentiallyFixableIssuesInfo.suggestionDisplay.View())
+	}
+
+	return customBorderStyle.Render(s.String())
 }
 
 func (m *FixableIssuesModel) handleSuggestionMsgs(msg tea.Msg) tea.Cmd {
@@ -569,12 +625,12 @@ func (m *FixableIssuesModel) setSuggestionDisplay(resetYOffset bool) {
 	}
 
 	var (
-		height         = m.body.Height() - leftStatusBorderStyle.GetVerticalBorderSize()
-		remainingWidth = m.getSuggestionWidth(m.getLeftStatusWidth())
+		height         = max(m.body.Height()-leftStatusBorderStyle.GetVerticalBorderSize()-strings.Count(m.suggestionHeaderView(), "\n"), 0)
+		remainingWidth = m.getSuggestionWidth(0)
 	)
 
 	if m.logFile != nil {
-		fmt.Fprintf(m.logFile, "Status width %d, body width %d, and a height of %d\n", m.getLeftStatusWidth(), remainingWidth, height)
+		fmt.Fprintf(m.logFile, "Status width %d, body width %d, and a height of %d\n", 0, remainingWidth, height)
 	}
 
 	m.PotentiallyFixableIssuesInfo.suggestionDisplay.SetHeight(height)


### PR DESCRIPTION
Fixes #108 

Changes Made:
- Got rid of the left pane and morphed it into the top of the suggestion window
- Reworked help keys to work better on a smaller screen and remove `ctrl` from the `pgdn` and `pgup` keys
- Recalculated sizes on editing mode changes to try to account for different sizes of the content in each mode and different keybindings
- Fixed setting potentially fixable suggestion index too high for final file